### PR TITLE
fix sup & sub docs

### DIFF
--- a/docs/src/sub.md
+++ b/docs/src/sub.md
@@ -14,49 +14,49 @@ Plugin to support subscript.
 @tab TS
 
 ```ts
-import MarkdownIt from "subdown-it";
+import MarkdownIt from "markdown-it";
 import { sub } from "@mdit/plugin-sub";
 
 const mdIt = MarkdownIt().use(sub);
 
-mdIt.render("19^th^");
+mdIt.render("H~2~O");
 ```
 
 @tab JS
 
 ```js
-const MarkdownIt = require("subdown-it");
+const MarkdownIt = require("markdown-it");
 const { sub } = require("@mdit/plugin-sub");
 
 const mdIt = MarkdownIt().use(sub);
 
-mdIt.render("19^th^");
+mdIt.render("H~2~O");
 ```
 
 :::
 
 ## Syntax
 
-Use `^ ^` to mark the subscript.
+Use `~ ~` to mark the subscript.
 
 ::: tip Escaping
 
-- You can use `\` to escape `^`:
+- You can use `\` to escape `~`:
 
   ```md
-  19\^th^
+  H\~2~O
   ```
 
   will be
 
-  19\^th^
+  H\~2~O
 
 :::
 
 ## Demo
 
-19^th^
+H~2~O
 
 ```md
-19^th^
+H~2~O
 ```

--- a/docs/src/sup.md
+++ b/docs/src/sup.md
@@ -14,49 +14,49 @@ Plugin to support superscript.
 @tab TS
 
 ```ts
-import MarkdownIt from "supdown-it";
+import MarkdownIt from "markdown-it";
 import { sup } from "@mdit/plugin-sup";
 
 const mdIt = MarkdownIt().use(sup);
 
-mdIt.render("H~2~O");
+mdIt.render("19^th^");
 ```
 
 @tab JS
 
 ```js
-const MarkdownIt = require("supdown-it");
+const MarkdownIt = require("markdown-it");
 const { sup } = require("@mdit/plugin-sup");
 
 const mdIt = MarkdownIt().use(sup);
 
-mdIt.render("H~2~O");
+mdIt.render("19^th^");
 ```
 
 :::
 
 ## Syntax
 
-Use `~ ~` to mark the superscript.
+Use `^ ^` to mark the superscript.
 
 ::: tip Escaping
 
 - You can use `\` to escape `^`:
 
   ```md
-  H\~2~O
+  19\^th^
   ```
 
   will be
 
-  H\~2~O
+  19\^th^
 
 :::
 
 ## Demo
 
-H~2~O
+19^th^
 
 ```md
-H~2~O
+19^th^
 ```

--- a/docs/src/zh/sub.md
+++ b/docs/src/zh/sub.md
@@ -14,49 +14,49 @@ icon: subscript
 @tab TS
 
 ```ts
-import MarkdownIt from "subdown-it";
+import MarkdownIt from "markdown-it";
 import { sub } from "@mdit/plugin-sub";
 
 const mdIt = MarkdownIt().use(sub);
 
-mdIt.render("19^th^");
+mdIt.render("H~2~O");
 ```
 
 @tab JS
 
 ```js
-const MarkdownIt = require("subdown-it");
+const MarkdownIt = require("markdown-it");
 const { sub } = require("@mdit/plugin-sub");
 
 const mdIt = MarkdownIt().use(sub);
 
-mdIt.render("19^th^");
+mdIt.render("H~2~O");
 ```
 
 :::
 
 ## 格式
 
-使用 `^ ^` 进行上角标标注。
+使用 `~ ~` 进行上角标标注。
 
 ::: tip 转义
 
-- 你可以使用 `\` 来转义 `^`:
+- 你可以使用 `\` 来转义 `~`:
 
   ```md
-  19\^th^
+  H\~2~O
   ```
 
   会被渲染为
 
-  19\^th^
+  H\~2~O
 
 :::
 
 ## 示例
 
-19^th^
+H~2~O
 
 ```md
-19^th^
+H~2~O
 ```

--- a/docs/src/zh/sup.md
+++ b/docs/src/zh/sup.md
@@ -14,38 +14,24 @@ icon: superscript
 @tab TS
 
 ```ts
-import MarkdownIt from "supdown-it";
+import MarkdownIt from "markdown-it";
 import { sup } from "@mdit/plugin-sup";
 
 const mdIt = MarkdownIt().use(sup);
 
-mdIt.render("H~2~O");
+mdIt.render("19^th^");
 ```
 
 @tab JS
 
 ```js
-const MarkdownIt = require("supdown-it");
+const MarkdownIt = require("markdown-it");
 const { sup } = require("@mdit/plugin-sup");
 
 const mdIt = MarkdownIt().use(sup);
 
-mdIt.render("H~2~O");
+mdIt.render("19^th^");
 ```
-
-:::
-
-::: tip 转义
-
-- 你可以使用 `\` 来转义 `~`:
-
-  ```md
-  H\~2~O
-  ```
-
-  会被渲染为
-
-  H\~2~O
 
 :::
 
@@ -53,10 +39,24 @@ mdIt.render("H~2~O");
 
 使用 `^ ^` 进行下角标标注。
 
+::: tip 转义
+
+- 你可以使用 `\` 来转义 `^`:
+
+  ```md
+  19\^th^
+  ```
+
+  会被渲染为
+
+  19\^th^
+
+:::
+
 ## 示例
 
-H~2~O
+19^th^
 
 ```md
-H~2~O
+19^th^
 ```


### PR DESCRIPTION
the examples were mixed up and i think a mistaken import name - although markdown-it-{sub,sup} both exist I don't think they're meant to be imported and follow other examples where it's just MarkdownIt being imported from markdown-it