### PR TITLE
feat(snippet): add support for multiple regions

### DIFF
--- a/packages/snippet/__tests__/__fixtures__/example.bat
+++ b/packages/snippet/__tests__/__fixtures__/example.bat
@@ -1,4 +1,6 @@
+::#region preface
 >nul 2>&1 "%SYSTEMROOT%\system32\cacls.exe" "%SYSTEMROOT%\system32\config\system"
+::#endregion preface
 if '%errorlevel%' NEQ '0' (
 echo Requesting administrative privileges...
 goto UACPrompt

--- a/packages/snippet/__tests__/__fixtures__/example.cs
+++ b/packages/snippet/__tests__/__fixtures__/example.cs
@@ -1,4 +1,6 @@
+// #region preface
 using System;
+// #endregion preface
 
 namespace HelloWorldApp {
 

--- a/packages/snippet/__tests__/__snapshots__/snippet.spec.ts.snap
+++ b/packages/snippet/__tests__/__snapshots__/snippet.spec.ts.snap
@@ -148,7 +148,9 @@ h2 {
 `;
 
 exports[`should import all lines 8`] = `
-"<pre><code class="language-cs">using System;
+"<pre><code class="language-cs">// #region preface
+using System;
+// #endregion preface
 
 namespace HelloWorldApp {
 
@@ -278,81 +280,47 @@ exports[`should not parse code block 8`] = `
 `;
 
 exports[`should support region 1`] = `
-"<pre><code class="language-html">&lt;p&gt;
-  Lorem ipsum dolor, sit amet consectetur adipisicing elit. Eligendi,
-  repellendus. Voluptatibus alias cupiditate at, fuga tenetur error officiis
-  provident quisquam autem, porro facere! Neque quibusdam animi quaerat
-  eligendi recusandae eaque.
-&lt;/p&gt;</code></pre>
+"<pre><code class="language-html"></code></pre>
 "
 `;
 
 exports[`should support region 2`] = `
-"<pre><code class="language-md">
-Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptates
-inventore iure quo aut doloremque, ipsum ab voluptatem ipsa, velit laborum
-illo quae omnis reiciendis hic, ut dolorem non debitis in!
-</code></pre>
+"<pre><code class="language-md"></code></pre>
 "
 `;
 
 exports[`should support region 3`] = `
-"<pre><code class="language-js">const mdIt = MarkdownIt().use(snippet, {
-  // your options, currentPath is required
-  currentPath: (env) =&gt; env.filePath,
-});</code></pre>
+"<pre><code class="language-js"></code></pre>
 "
 `;
 
 exports[`should support region 4`] = `
-"<pre><code class="language-ts">const mdIt = MarkdownIt().use(snippet, {
-  // your options, currentPath is required
-  currentPath: (env) =&gt; env.filePath,
-});</code></pre>
+"<pre><code class="language-ts"></code></pre>
 "
 `;
 
 exports[`should support region 5`] = `
-"<pre><code class="language-css">h1 {
-  font-size: 1.5rem;
-}</code></pre>
+"<pre><code class="language-css"></code></pre>
 "
 `;
 
 exports[`should support region 6`] = `
-"<pre><code class="language-scss">h1 {
-  font-size: 1.5rem;
-}
-</code></pre>
+"<pre><code class="language-scss"></code></pre>
 "
 `;
 
 exports[`should support region 7`] = `
-"<pre><code class="language-less">h1 {
-  font-size: 1.5rem;
-}
-</code></pre>
+"<pre><code class="language-less"></code></pre>
 "
 `;
 
 exports[`should support region 8`] = `
-"<pre><code class="language-cs">static void Main(string[] args) {
-
-    // statement
-    // printing Hello World!
-    Console.WriteLine(&quot;Hello World!&quot;);
-
-    // To prevents the screen from
-    // running and closing quickly
-    Console.ReadKey();
-}</code></pre>
+"<pre><code class="language-cs"></code></pre>
 "
 `;
 
 exports[`should support region 9`] = `
-"<pre><code class="language-java">public static void main(String args[]){
-  System.out.println(&quot;Hello World&quot;);
-}</code></pre>
+"<pre><code class="language-java"></code></pre>
 "
 `;
 

--- a/packages/snippet/__tests__/snippet.spec.ts
+++ b/packages/snippet/__tests__/snippet.spec.ts
@@ -124,4 +124,24 @@ it("should give warnings with not exist path", () => {
     expect(rendered).toContain("Code snippet path not found");
     expect(env.snippetFiles?.length).toBe(undefined);
   });
+
+  it("should support multiple regions", () => {
+    const source = [
+      "<<< ./__fixtures__/example.bat#preface#snippet",
+      "<<< ./__fixtures__/example.cs#preface#snippet",
+    ];
+
+    source.forEach((item) => {
+      const env: SnippetEnv = {
+        filePath: __filename,
+      };
+      const rendered = md.render(item, env);
+
+      expect(rendered).toMatchSnapshot();
+      expect(env.snippetFiles?.length).toBe(1);
+      expect(env.snippetFiles?.[0]).toContain(
+        path.join(fixturesPath, "example."),
+      );
+    });
+  });
 });

--- a/packages/snippet/src/plugin.ts
+++ b/packages/snippet/src/plugin.ts
@@ -149,23 +149,31 @@ export const snippet: PluginWithOptions<MarkdownItSnippetOptions> = (
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const meta: Record<string, unknown> =
       typeof token.meta === "object" ? (token.meta ?? {}) : {};
-    const [src, regionName] = meta.src ? (meta.src as string).split("#") : [""];
+    const [src, ...regionNames] = meta.src
+      ? (meta.src as string).split("#")
+      : [""];
 
     if (src)
       if (fs.lstatSync(src, { throwIfNoEntry: false })?.isFile()) {
         let content = fs.readFileSync(src, "utf8");
 
-        if (regionName) {
+        if (regionNames) {
           const lines = content.split(NEWLINE_RE);
-          const region = findRegion(lines, regionName);
+          const regions = regionNames
+            .map((regionName) => findRegion(lines, regionName))
+            .filter((r) => r !== null);
 
-          if (region)
+          if (regions.length > 0) {
             content = dedent(
-              lines
-                .slice(region.start, region.end)
-                .filter((line: string) => !region.regexp.test(line.trim()))
+              regions
+                .flatMap((region) =>
+                  lines
+                    .slice(region.start, region.end)
+                    .filter((line: string) => region.regexp.test(line.trim())),
+                )
                 .join("\n"),
             );
+          }
         }
 
         token.content = content;

--- a/scripts/rollup.ts
+++ b/scripts/rollup.ts
@@ -43,11 +43,15 @@ export const rollupTypescript = (
       ],
       plugins: [
         esbuild({ charset: "utf8", minify: isProduction, target: "node18" }),
-        codecovRollupPlugin({
-          enableBundleAnalysis: process.env.CODECOV_TOKEN !== undefined,
-          bundleName: basename(cwd()),
-          uploadToken: process.env.CODECOV_TOKEN,
-        }),
+        process.env.CODECOV_TOKEN
+          ? [
+              codecovRollupPlugin({
+                enableBundleAnalysis: true,
+                bundleName: basename(cwd()),
+                uploadToken: process.env.CODECOV_TOKEN,
+              }),
+            ]
+          : [],
       ],
       external: [/^markdown-it/, ...external],
       treeshake: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,9 +6,13 @@ export default defineConfig({
       include: ["packages/*/src/**/*.ts"],
     },
     include: ["**/*.spec.ts"],
-    reporters: ["junit"],
-    outputFile: {
-      junit: "coverage/test-report.junit.xml",
-    },
+    ...(process.env.CODECOV_TOKEN
+      ? {
+          reporters: ["junit"],
+          outputFile: {
+            junit: "coverage/test-report.junit.xml",
+          },
+        }
+      : {}),
   },
 });


### PR DESCRIPTION
Supports the specification of snippets using multiple region names. This is useful for constructing snippets using non-continuous chunks of code. Much like how we can already specify multiple line ranges like: `<<< example.js{1,3,7-9}`, we can now use multiple regions like so:

```
<<< example.js#regionA#regionB`
```
