### PR TITLE
fix(footnote): stop using self-closing syntax `<a />` as it breaks in some HTML interpreters

### DIFF
--- a/packages/footnote/src/plugin.ts
+++ b/packages/footnote/src/plugin.ts
@@ -78,7 +78,7 @@ const renderFootnoteRef: RenderRule = (
   return `<sup class="footnote-ref"><a href="#footnote${id}">${caption}</a><a class="footnote-anchor" id="footnote-ref${id}${getIDSuffix(
     tokens,
     index,
-  )}" /></sup>`;
+  )}"></a></sup>`;
 };
 
 const renderFootnoteBlockOpen: RenderRule = (


### PR DESCRIPTION


[When extending the markdown syntax in Visual Studio Code](https://code.visualstudio.com/api/extension-guides/markdown-extension#adding-support-for-new-syntax-with-markdownit-plugins) by using the footnote plugin, the rendered markdown document breaks and all the content after the `<a />` tag is wrapped in this link.

<img width="315" alt="image" src="https://github.com/user-attachments/assets/7846efd1-0b03-4e45-952c-bb4d1e22af63" />

This PR swaps the `<a />` syntax for `<a></a>`.

Also, thank you so much for your great work on those plugins, they're amazing! 🙏