### PR TITLE
docs(uml): fix missing commas in TS and JS usage examples

### DIFF
--- a/docs/src/uml.md
+++ b/docs/src/uml.md
@@ -18,7 +18,7 @@ import MarkdownIt from "markdown-it";
 import { uml } from "@mdit/plugin-uml";
 
 const mdIt = MarkdownIt().use(uml, {
-  name: 'demo'
+  name: 'demo',
   open: 'demostart',
   close: 'demoend',
   render: (tokens, index) => {
@@ -41,7 +41,7 @@ const MarkdownIt = require("markdown-it");
 const { uml } = require("@mdit/plugin-uml");
 
 const mdIt = MarkdownIt().use(uml, {
-  name: 'demo'
+  name: 'demo',
   open: 'demostart',
   close: 'demoend',
   render: (tokens, index) => {


### PR DESCRIPTION
This commit adds the missing commas to ensure the examples are syntactically correct and match the expected usage of the @mdit/plugin-uml plugin.