### PR TITLE
fix(mathjax): use tex font to avoid dynamic imports

### DIFF
--- a/packages/mathjax-slim/package.json
+++ b/packages/mathjax-slim/package.json
@@ -48,9 +48,11 @@
     "@types/markdown-it": "^14.1.2"
   },
   "devDependencies": {
-    "@mathjax/src": "4.0.0"
+    "@mathjax/mathjax-tex-font": "^4.0.0",
+    "@mathjax/src": "^4.0.0"
   },
   "peerDependencies": {
+    "@mathjax/mathjax-tex-font": "^4.0.0",
     "@mathjax/src": "^4.0.0",
     "markdown-it": "^14.1.0"
   },

--- a/packages/mathjax-slim/rollup.config.ts
+++ b/packages/mathjax-slim/rollup.config.ts
@@ -2,10 +2,10 @@ import { rollupTypescript } from "../../scripts/rollup.js";
 
 export default [
   ...rollupTypescript("index", {
-    external: [/^@mathjax\/src\//],
+    external: [/^@mathjax\/src\//, /^@mathjax\/mathjax-.*-font\//],
   }),
   ...rollupTypescript("sync", {
-    external: [/^@mathjax\/src\//],
+    external: [/^@mathjax\/src\//, /^@mathjax\/mathjax-.*-font\//],
     output: {
       dir: "./lib",
       file: undefined,

--- a/packages/mathjax-slim/src/mathjax.ts
+++ b/packages/mathjax-slim/src/mathjax.ts
@@ -47,12 +47,10 @@ export interface MathJaxTexInputOptions {
    * extensions to use
    *
    * @default [
-   *   'base',
    *   'action',
    *   'ams',
    *   'amscd',
    *   'bbm',
-   *   'bboldx',
    *   'bbox',
    *   'begingroup',
    *   'boldsymbol',

--- a/packages/mathjax-slim/src/plugin.ts
+++ b/packages/mathjax-slim/src/plugin.ts
@@ -2,6 +2,7 @@
  * Forked from https://github.com/tani/markdown-it-mathjax3/blob/master/index.ts
  */
 
+import { MathJaxTexFont } from "@mathjax/mathjax-tex-font/js/svg.js";
 import type { AssistiveMmlHandler as AssistiveMmlHandlerType } from "@mathjax/src/js/a11y/assistive-mml.js";
 import type { LiteDocument } from "@mathjax/src/js/adaptors/lite/Document.js";
 import type {
@@ -23,7 +24,7 @@ import { tex } from "@mdit/plugin-tex";
 import type MarkdownIt from "markdown-it";
 
 import type { MarkdownItMathjaxOptions, TeXTransformer } from "./options.js";
-import { loadTexPackages, texPackages } from "./tex/index.js";
+import { defaultTexPackages, loadTexPackages } from "./tex/index.js";
 
 let isMathJaxFullInstalled = true;
 let mathjaxLib: typeof mathjaxType;
@@ -70,8 +71,8 @@ export const getDocumentOptions = async (
 
   return {
     InputJax: new TeX<LiteElement, string, HTMLElement>({
-      packages: ["base", ...texPackages],
       ...options.tex,
+      packages: ["base", ...(options.tex?.packages ?? defaultTexPackages)],
     }),
     OutputJax:
       options.output === "chtml"
@@ -81,6 +82,7 @@ export const getDocumentOptions = async (
           })
         : new SVG<LiteElement, string, HTMLElement>({
             fontCache: "none",
+            fontData: MathJaxTexFont,
             ...options.svg,
           }),
     enableAssistiveMml: options.a11y !== false,

--- a/packages/mathjax-slim/src/sync.ts
+++ b/packages/mathjax-slim/src/sync.ts
@@ -23,7 +23,7 @@ import { tex } from "@mdit/plugin-tex";
 import type MarkdownIt from "markdown-it";
 
 import type { MarkdownItMathjaxOptions, TeXTransformer } from "./options.js";
-import { texPackages } from "./tex/index.js";
+import { defaultTexPackages } from "./tex/index.js";
 
 let isMathJaxFullInstalled = true;
 let mathjaxLib: typeof mathjaxType;
@@ -69,8 +69,8 @@ export const getDocumentOptions = (
 
   return {
     InputJax: new TeX<LiteElement, string, HTMLElement>({
-      packages: ["base", ...texPackages],
       ...options.tex,
+      packages: ["base", ...defaultTexPackages],
     }),
     OutputJax:
       options.output === "chtml"

--- a/packages/mathjax-slim/src/tex/packages.ts
+++ b/packages/mathjax-slim/src/tex/packages.ts
@@ -40,3 +40,7 @@ export const texPackages: TexPackage[] = [
   "upgreek",
   "verb",
 ];
+
+export const defaultTexPackages: TexPackage[] = texPackages.filter(
+  (pkg) => pkg !== "bboldx",
+);

--- a/packages/mathjax-slim/src/tex/utils.ts
+++ b/packages/mathjax-slim/src/tex/utils.ts
@@ -1,9 +1,9 @@
 import type { TexPackage } from "../mathjax.js";
 import { texLoaders } from "./loader.js";
-import { texPackages } from "./packages.js";
+import { defaultTexPackages, texPackages } from "./packages.js";
 
 export const loadTexPackages = async (
-  packages: TexPackage[] = texPackages,
+  packages: TexPackage[] = defaultTexPackages,
 ): Promise<void> => {
   await import("@mathjax/src/js/input/tex/base/BaseConfiguration.js");
 

--- a/packages/mathjax/package.json
+++ b/packages/mathjax/package.json
@@ -44,6 +44,7 @@
     "clean": "rimraf ./lib"
   },
   "dependencies": {
+    "@mathjax/mathjax-tex-font": "^4.0.0",
     "@mathjax/src": "^4.0.0",
     "@mdit/plugin-tex": "workspace:*",
     "@types/markdown-it": "^14.1.2"

--- a/packages/mathjax/rollup.config.ts
+++ b/packages/mathjax/rollup.config.ts
@@ -2,10 +2,10 @@ import { rollupTypescript } from "../../scripts/rollup.js";
 
 export default [
   ...rollupTypescript("index", {
-    external: [/^@mathjax\/src\//],
+    external: [/^@mathjax\/src\//, /^@mathjax\/mathjax-.*-font\//],
   }),
   ...rollupTypescript("sync", {
-    external: [/^@mathjax\/src\//],
+    external: [/^@mathjax\/src\//, /^@mathjax\/mathjax-.*-font\//],
     treeshake: {},
   }),
 ];

--- a/packages/mathjax/src/mathjax.ts
+++ b/packages/mathjax/src/mathjax.ts
@@ -47,12 +47,10 @@ export interface MathJaxTexInputOptions {
    * extensions to use
    *
    * @default [
-   *   'base',
    *   'action',
    *   'ams',
    *   'amscd',
    *   'bbm',
-   *   'bboldx',
    *   'bbox',
    *   'begingroup',
    *   'boldsymbol',

--- a/packages/mathjax/src/plugin.ts
+++ b/packages/mathjax/src/plugin.ts
@@ -2,6 +2,7 @@
  * Forked from https://github.com/tani/markdown-it-mathjax3/blob/master/index.ts
  */
 
+import { MathJaxTexFont } from "@mathjax/mathjax-tex-font/js/svg.js";
 import { AssistiveMmlHandler } from "@mathjax/src/js/a11y/assistive-mml.js";
 import type { LiteDocument } from "@mathjax/src/js/adaptors/lite/Document.js";
 import type {
@@ -21,7 +22,7 @@ import { tex } from "@mdit/plugin-tex";
 import type MarkdownIt from "markdown-it";
 
 import type { MarkdownItMathjaxOptions, TeXTransformer } from "./options.js";
-import { loadTexPackages, texPackages } from "./tex/index.js";
+import { defaultTexPackages, loadTexPackages } from "./tex/index.js";
 
 import "./tex/importer.js";
 
@@ -40,8 +41,8 @@ export const getDocumentOptions = async (
 
   return {
     InputJax: new TeX<LiteElement, string, HTMLElement>({
-      packages: ["base", ...texPackages],
       ...options.tex,
+      packages: ["base", ...(options.tex?.packages ?? defaultTexPackages)],
     }),
     OutputJax:
       options.output === "chtml"
@@ -51,6 +52,7 @@ export const getDocumentOptions = async (
           })
         : new SVG<LiteElement, string, HTMLElement>({
             fontCache: "none",
+            fontData: MathJaxTexFont,
             ...options.svg,
           }),
     enableAssistiveMml: options.a11y !== false,

--- a/packages/mathjax/src/sync.ts
+++ b/packages/mathjax/src/sync.ts
@@ -21,7 +21,7 @@ import { tex } from "@mdit/plugin-tex";
 import type MarkdownIt from "markdown-it";
 
 import type { MarkdownItMathjaxOptions, TeXTransformer } from "./options.js";
-import { texPackages } from "./tex/index.js";
+import { defaultTexPackages } from "./tex/index.js";
 
 import "./tex/importer.js";
 
@@ -37,8 +37,8 @@ export const getDocumentOptions = (
   options: MarkdownItMathjaxOptions,
 ): DocumentOptions => ({
   InputJax: new TeX<LiteElement, string, HTMLElement>({
-    packages: ["base", ...texPackages],
     ...options.tex,
+    packages: ["base", ...defaultTexPackages],
   }),
   OutputJax:
     options.output === "chtml"

--- a/packages/mathjax/src/tex/packages.ts
+++ b/packages/mathjax/src/tex/packages.ts
@@ -40,3 +40,7 @@ export const texPackages: TexPackage[] = [
   "upgreek",
   "verb",
 ];
+
+export const defaultTexPackages: TexPackage[] = texPackages.filter(
+  (pkg) => pkg !== "bboldx",
+);

--- a/packages/mathjax/src/tex/utils.ts
+++ b/packages/mathjax/src/tex/utils.ts
@@ -1,9 +1,9 @@
 import type { TexPackage } from "../mathjax.js";
 import { texLoaders } from "./loader.js";
-import { texPackages } from "./packages.js";
+import { defaultTexPackages, texPackages } from "./packages.js";
 
 export const loadTexPackages = async (
-  packages: TexPackage[] = texPackages,
+  packages: TexPackage[] = defaultTexPackages,
 ): Promise<void> => {
   await import("@mathjax/src/js/input/tex/base/BaseConfiguration.js");
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
 
   packages/mathjax:
     dependencies:
+      '@mathjax/mathjax-tex-font':
+        specifier: ^4.0.0
+        version: 4.1.0
       '@mathjax/src':
         specifier: ^4.0.0
         version: 4.0.0
@@ -434,8 +437,11 @@ importers:
         specifier: ^14.1.0
         version: 14.1.0
     devDependencies:
+      '@mathjax/mathjax-tex-font':
+        specifier: ^4.0.0
+        version: 4.1.0
       '@mathjax/src':
-        specifier: 4.0.0
+        specifier: ^4.0.0
         version: 4.0.0
 
   packages/plantuml:
@@ -1406,6 +1412,9 @@ packages:
 
   '@mathjax/mathjax-newcm-font@4.0.0':
     resolution: {integrity: sha512-kpsJgIF4FpWiwIkFgOPmWwy5GXfL25spmJJNg27HQxPddmEL8Blx0jn2BuU/nlwjM/9SnYpEfDrWiAMgLPlB8Q==}
+
+  '@mathjax/mathjax-tex-font@4.1.0':
+    resolution: {integrity: sha512-PnlkYIcY4fPjmbN0AGLTULD8nSC2isrCmquEyuHzGU9dAOvLvapYWi5/2yOu0+ZRDDxgs0cAtg52fYQMkirxrQ==}
 
   '@mathjax/src@4.0.0':
     resolution: {integrity: sha512-i7oYVLkHTskfTqxBzrbvcJN8ptGChWb6bx2LZsCySk7QWf61JqaMYX5N7M0qr8tnYqRmN5DDedkRda7wDuTdBA==}
@@ -6379,6 +6388,8 @@ snapshots:
       '@lit-labs/ssr-dom-shim': 1.4.0
 
   '@mathjax/mathjax-newcm-font@4.0.0': {}
+
+  '@mathjax/mathjax-tex-font@4.1.0': {}
 
   '@mathjax/src@4.0.0':
     dependencies:


### PR DESCRIPTION
When using variants such as `\mathbb` and `\mathcal`, MathJax4 will load dynamic files synchronously, excpet for the old `tex` font.
This commit sets `mathjax-tex-font` as the default, and excludes the extension `bboldx` which redefines `\mathbb` from being autoloaded.