### PR TITLE
fix(plugin-emoji): export options type, fix readme description

### DIFF
--- a/packages/plugin-emoji/README.md
+++ b/packages/plugin-emoji/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@mdit/plugin-emoji.svg?style=flat-square&logo=npm) ![Downloads](https://img.shields.io/npm/dm/@mdit/plugin-emoji.svg?style=flat-square&logo=npm) ![Size](https://img.shields.io/bundlephobia/min/@mdit/plugin-emoji?style=flat-square&logo=npm)](https://www.npmjs.com/package/@mdit/plugin-emoji)
 
-Figure plugin for MarkdownIt.
+Emoji plugin for MarkdownIt.
 
 ## [Docs](https://mdit-plugins.github.io/emoji.html) | [文档](https://mdit-plugins.github.io/zh/emoji.html)
 

--- a/packages/plugin-emoji/src/index.ts
+++ b/packages/plugin-emoji/src/index.ts
@@ -1,3 +1,4 @@
+export type * from "./options.js";
 export * from "./bare.js";
 export * from "./light.js";
 export * from "./full.js";

--- a/scripts/verifyCommit.ts
+++ b/scripts/verifyCommit.ts
@@ -12,9 +12,7 @@ const getSubDirectories = async (dir: string): Promise<string[]> => {
   return items.filter((_, index) => stats[index].isDirectory());
 };
 
-const pluginPackages = (await getSubDirectories(path.join(__dirname, "../packages"))).map((dir) =>
-  dir === "helper" ? "helper" : `plugin-${dir}`,
-);
+const pluginPackages = await getSubDirectories(path.join(__dirname, "../packages"));
 
 const msgPath = process.argv[2]
   ? path.resolve(process.argv[2])


### PR DESCRIPTION
- Exports `EmojiPluginOptions` from the package entry like the sibling packages do - consumers currently have to derive it via `Parameters<typeof fullEmoji>[1]`.
- Fixes the readme, which described the package as the figure plugin.
- Drive-by: fixes the commit scope check in `scripts/verifyCommit.ts`, which still prepends `plugin-` to the already-renamed package directories after #571, so the only accepted scope for this package was `plugin-plugin-emoji`.

Note: several other readmes have the same copy-paste issue (`helper` says "Image lazyload plugin", and `plugin-dl` / `plugin-ins` / `plugin-ruby` / `plugin-spoiler` all say "Mark plugin") - left out of this PR to keep it scoped, happy to fix those too if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)