### PR TITLE
fix(plugin-attrs): align behavior with markdown-it-attrs

### DIFF
--- a/packages/plugin-attrs/__tests__/helper/getDelimiterChecker.spec.ts
+++ b/packages/plugin-attrs/__tests__/helper/getDelimiterChecker.spec.ts
@@ -30,6 +30,30 @@ describe(createDelimiterChecker, () => {
     expect(checker("")).toBe(false);
   });
 
+  it("should ignore delimiters inside quoted values", () => {
+    const startChecker = createDelimiterChecker(options, "start");
+    const endChecker = createDelimiterChecker(options, "end");
+
+    // delimiters inside a quoted value must not start or end the block
+    expect(endChecker('text {.replace-me data-tex="e^{i}=-1"}')).toStrictEqual([6, 37]);
+    expect(startChecker('{a="}"} text')).toStrictEqual([1, 6]);
+
+    // a left delimiter inside an unbalanced quote is not a delimiter
+    expect(endChecker('he said "hi {.c}')).toBe(false);
+
+    // an unterminated block whose only right delimiter is quoted
+    expect(endChecker('x {a="}" y')).toBe(false);
+
+    // escaped quotes do not end a quoted value
+    expect(endChecker(String.raw`text {a="x\" y"}`)).toStrictEqual([6, 15]);
+
+    // a quote at the very start of the content
+    expect(endChecker('"a" {.c}')).toStrictEqual([5, 7]);
+
+    // quotes before the block do not affect end detection
+    expect(endChecker('he said "hi" {.c}')).toStrictEqual([14, 16]);
+  });
+
   it("should check only delimiter", () => {
     const checker = createDelimiterChecker(options, "only");
 

--- a/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
@@ -1,9 +1,15 @@
+import { katex } from "@mdit/plugin-katex";
 import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
 import type { MarkdownItAttrsOptions } from "../../src/index.js";
 import { attrs } from "../../src/index.js";
 import { replaceDelimiters } from "../replaceDelimiters.js";
+import {
+  headingAnchorPlugin,
+  trailingSpacePlugin,
+  unmatchedOpenPlugin,
+} from "../simulatedPlugins.js";
 
 const createDualRuleTests = (
   baseOptions: MarkdownItAttrsOptions & { left: string; right: string },
@@ -205,13 +211,13 @@ const createDualRuleTests = (
 
       it(
         replaceDelimiters(
-          "should handle nested block structures with multiple closing tokens",
+          "should apply attributes to the innermost block in nested structures",
           options,
         ),
         () => {
           const src = "> > nested blockquote {.nested}";
           const expected =
-            '<blockquote class="nested">\n<blockquote>\n<p>nested blockquote</p>\n</blockquote>\n</blockquote>\n';
+            '<blockquote>\n<blockquote>\n<p class="nested">nested blockquote</p>\n</blockquote>\n</blockquote>\n';
 
           expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
         },
@@ -244,3 +250,54 @@ createDualRuleTests(
   },
   "with [[ ]] delimiters",
 );
+
+describe("end of block child search", () => {
+  it("should find attrs before tokens appended by heading anchor style plugins", () => {
+    const markdownIt = MarkdownIt();
+
+    headingAnchorPlugin(markdownIt);
+    markdownIt.use(attrs);
+
+    expect(markdownIt.render("## H2 heading {#my-id}")).toBe(
+      '<h2 id="my-id">H2 heading <a href="#">#</a></h2>\n',
+    );
+  });
+
+  it("should skip trailing whitespace-only text children", () => {
+    const markdownIt = MarkdownIt();
+
+    trailingSpacePlugin(markdownIt);
+    markdownIt.use(attrs);
+
+    expect(markdownIt.render("text {.c}")).toBe('<p class="c">text </p>\n');
+  });
+
+  it("should skip trailing top level non-text tokens", () => {
+    const markdownIt = MarkdownIt({ html: true }).use(attrs);
+
+    expect(markdownIt.render("text {.c}<br>")).toBe('<p class="c">text<br></p>\n');
+  });
+
+  it("should not search past inline code", () => {
+    const markdownIt = MarkdownIt().use(attrs);
+
+    expect(markdownIt.render("text {.c}`code`")).toBe("<p>text {.c}<code>code</code></p>\n");
+  });
+
+  it("should not search past inline math", () => {
+    const markdownIt = MarkdownIt().use(attrs).use(katex);
+    const markdownItWithOnlyKatex = MarkdownIt().use(katex);
+    const src = "text {.c}$a$";
+
+    expect(markdownIt.render(src)).toBe(markdownItWithOnlyKatex.render(src));
+  });
+
+  it("should stop at unmatched opening tags", () => {
+    const markdownIt = MarkdownIt();
+
+    unmatchedOpenPlugin(markdownIt);
+    markdownIt.use(attrs);
+
+    expect(markdownIt.render("text {.c}")).toBe("<p>text {.c}<a></p>\n");
+  });
+});

--- a/packages/plugin-attrs/__tests__/rules/table.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/table.spec.ts
@@ -27,7 +27,6 @@ const createDualRuleTests = (
 | ------- | ------- |
 | cell1   | cell2   |
 
-
 {.class}`;
 
         const expected = `\
@@ -408,6 +407,106 @@ const createDualRuleTests = (
         testCases.forEach(([src, expected]) => {
           expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
         });
+      });
+
+      it(replaceDelimiters("should apply attributes after a table with spans", options), () => {
+        const src = `\
+| A                        | B   | C   | D              |
+| ------------------------ | --- | --- | -------------- |
+| A1                       | B1  | C1  | D1 {rowspan=3} |
+| A2 {colspan=2 rowspan=2} | B2  | C2  | D2             |
+| A3                       | B3  | C3  | D3             |
+
+{.table border=1}
+`;
+
+        const expected = `\
+<table class="table" border="1">
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+<th>C</th>
+<th>D</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>A1</td>
+<td>B1</td>
+<td>C1</td>
+<td rowspan="3">D1</td>
+</tr>
+<tr>
+<td colspan="2" rowspan="2">A2</td>
+<td>C2</td>
+</tr>
+<tr>
+<td>C3</td>
+</tr>
+</tbody>
+</table>
+`;
+
+        expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
+      });
+
+      it(replaceDelimiters("should support consecutive tables with spans", options), () => {
+        const src = `\
+| A                        | B   | C   | D              |
+| ------------------------ | --- | --- | -------------- |
+| A1                       | B1  | C1  | D1 {rowspan=3} |
+| A2 {colspan=2 rowspan=2} | B2  | C2  | D2             |
+| A3                       | B3  | C3  | D3             |
+
+{border=1}
+| E | F |
+| --- | --- |
+| E1 {colspan=2} |
+`;
+
+        const expected = `\
+<table border="1">
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+<th>C</th>
+<th>D</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>A1</td>
+<td>B1</td>
+<td>C1</td>
+<td rowspan="3">D1</td>
+</tr>
+<tr>
+<td colspan="2" rowspan="2">A2</td>
+<td>C2</td>
+</tr>
+<tr>
+<td>C3</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>E</th>
+<th>F</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">E1</td>
+</tr>
+</tbody>
+</table>
+`;
+
+        expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
       });
 
       it(replaceDelimiters("should support empty inline tokens", options), () => {

--- a/packages/plugin-attrs/__tests__/simulatedPlugins.ts
+++ b/packages/plugin-attrs/__tests__/simulatedPlugins.ts
@@ -1,0 +1,71 @@
+/**
+ * Simulated plugins that inject inline children before the attrs rule runs.
+ *
+ * They register with `md.core.ruler.before("linkify", ...)` so they run ahead of the attrs rule -
+ * real plugins with this ordering exist, but e.g. `@mdit/plugin-anchor` pushes its rule to the end
+ * of the core chain and runs after the attrs rule, so it cannot reproduce it.
+ */
+import type MarkdownIt from "markdown-it";
+
+/**
+ * Simulate a navigation / heading anchor plugin appending a permalink after the heading text, so
+ * the attribute text is no longer the last child of the inline token
+ *
+ * @param md - The markdown-it instance to install the rule on
+ */
+export const headingAnchorPlugin = (md: MarkdownIt): void => {
+  md.core.ruler.before("linkify", "heading_anchor_test", (state) => {
+    state.tokens.forEach((token, index) => {
+      if (token.type !== "heading_open") return;
+
+      const space = new state.Token("text", "", 0);
+
+      space.content = " ";
+
+      const anchorOpen = new state.Token("link_open", "a", 1);
+
+      anchorOpen.attrs = [["href", "#"]];
+
+      const anchorSymbol = new state.Token("html_inline", "", 0);
+
+      anchorSymbol.content = "#";
+
+      const anchorClose = new state.Token("link_close", "a", -1);
+
+      state.tokens[index + 1].children?.push(space, anchorOpen, anchorSymbol, anchorClose);
+    });
+  });
+};
+
+/**
+ * Simulate a plugin appending a whitespace-only text token after the attribute text
+ *
+ * @param md - The markdown-it instance to install the rule on
+ */
+export const trailingSpacePlugin = (md: MarkdownIt): void => {
+  md.core.ruler.before("linkify", "trailing_space_test", (state) => {
+    state.tokens.forEach((token) => {
+      if (token.type !== "inline") return;
+
+      const space = new state.Token("text", "", 0);
+
+      space.content = " ";
+      token.children?.push(space);
+    });
+  });
+};
+
+/**
+ * Simulate a plugin appending an opening tag without its closing counterpart
+ *
+ * @param md - The markdown-it instance to install the rule on
+ */
+export const unmatchedOpenPlugin = (md: MarkdownIt): void => {
+  md.core.ruler.before("linkify", "unmatched_open_test", (state) => {
+    state.tokens.forEach((token) => {
+      if (token.type !== "inline") return;
+
+      token.children?.push(new state.Token("link_open", "a", 1));
+    });
+  });
+};

--- a/packages/plugin-attrs/src/helper/constants.ts
+++ b/packages/plugin-attrs/src/helper/constants.ts
@@ -8,3 +8,5 @@ export const PAIR_SEPARATOR = 32;
 export const KEY_SEPARATOR = 61;
 /** " */
 export const QUOTE_MARKER = 34;
+/** \ */
+export const ESCAPE_MARKER = 92;

--- a/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
+++ b/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
@@ -1,6 +1,49 @@
 import type { DelimiterChecker } from "../rules/types.js";
-import { CLASS_MARKER, ID_MARKER } from "./constants.js";
+import { CLASS_MARKER, ESCAPE_MARKER, ID_MARKER, QUOTE_MARKER } from "./constants.js";
 import type { DelimiterConfig } from "./types.js";
+
+// Check whether the character at the given index is a double quote that is not escaped
+const isUnescapedQuote = (content: string, index: number): boolean => {
+  if (content.charCodeAt(index) !== QUOTE_MARKER) return false;
+
+  let escapeCount = 0;
+
+  for (let i = index - 1; i >= 0 && content.charCodeAt(i) === ESCAPE_MARKER; i--) escapeCount++;
+
+  return escapeCount % 2 === 0;
+};
+
+// Find the first occurrence of the delimiter outside quoted values, starting at `from`
+const findDelimiter = (content: string, from: number, delimiter: string): number => {
+  // Fast path: without quotes in the searched range there are no quoted values
+  // to skip (the scan below never consults anything before `from` either)
+  if (!content.includes('"', from)) return content.indexOf(delimiter, from);
+
+  let insideQuotes = false;
+
+  for (let index = from; index < content.length; index++) {
+    if (isUnescapedQuote(content, index)) insideQuotes = !insideQuotes;
+    else if (!insideQuotes && content.startsWith(delimiter, index)) return index;
+  }
+
+  return -1;
+};
+
+// Find the last occurrence of the left delimiter outside quoted values
+const findLastLeftDelimiter = (content: string, left: string): number => {
+  // Fast path: without quotes there are no quoted values to skip
+  if (!content.includes('"')) return content.lastIndexOf(left);
+
+  let result = -1;
+  let insideQuotes = false;
+
+  for (let index = 0; index < content.length; index++) {
+    if (isUnescapedQuote(content, index)) insideQuotes = !insideQuotes;
+    else if (!insideQuotes && content.startsWith(left, index)) result = index;
+  }
+
+  return result;
+};
 
 /**
  * Get a function to check if a string matches the delimiter pattern 获取一个函数来检查字符串是否匹配分隔符模式
@@ -35,7 +78,7 @@ export const createDelimiterChecker = (
       if (!content.startsWith(left)) return false;
 
       start = leftLength;
-      end = content.indexOf(right, leftLength + 1);
+      end = findDelimiter(content, leftLength + 1, right);
 
       if (end === -1) return false;
 
@@ -45,11 +88,11 @@ export const createDelimiterChecker = (
       if (nextCharPos < content.length && right.includes(content.charAt(nextCharPos))) return false;
     } else if (where === "end") {
       // Check if content ends with right delimiter
-      start = content.lastIndexOf(left);
+      start = findLastLeftDelimiter(content, left);
 
       if (start === -1) return false;
 
-      end = content.indexOf(right, start + leftLength + 1);
+      end = findDelimiter(content, start + leftLength + 1, right);
       start += leftLength;
 
       if (end === -1 || end + rightLength !== content.length) return false;

--- a/packages/plugin-attrs/src/plugin.ts
+++ b/packages/plugin-attrs/src/plugin.ts
@@ -39,8 +39,14 @@ export const attrs: PluginWithOptions<MarkdownItAttrsOptions> = (
         });
 
         if (match) {
+          const currentToken = tokens[index];
+
           // oxlint-disable-next-line typescript/no-non-null-assertion
           pattern.transform(tokens, index, position!, range!);
+
+          // re-locate the current token in case the transform spliced tokens
+          // before it (e.g. the table calculate rule removing covered cells)
+          if (tokens[index] !== currentToken) index = tokens.indexOf(currentToken);
 
           if (
             pattern.name === "inline attributes" ||

--- a/packages/plugin-attrs/src/rules/blockEnd.ts
+++ b/packages/plugin-attrs/src/rules/blockEnd.ts
@@ -1,12 +1,61 @@
 import type MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
 
 import type { DelimiterConfig } from "../helper/index.js";
 import { addAttrs, createDelimiterChecker, getMatchingOpeningToken } from "../helper/index.js";
-import type { AttrRule } from "./types.js";
+import type { AttrRule, DelimiterRange } from "./types.js";
 import { defineAttrRule } from "./types.js";
 
 export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): AttrRule => {
   const isSpace = md.utils.isSpace;
+  const isWhiteSpace = md.utils.isWhiteSpace;
+  const endDelimiterChecker = createDelimiterChecker(options, "end");
+
+  // Non-allocating `content.trim() === ""`
+  const isWhitespaceOnly = (content: string): boolean => {
+    for (let index = 0; index < content.length; index++)
+      if (!isWhiteSpace(content.charCodeAt(index))) return false;
+
+    return true;
+  };
+
+  // Find the last meaningful text child - the one end-of-block attributes live on - skipping
+  // trailing whitespace-only text and balanced tag pairs (e.g. an appended permalink); returns -1
+  // when inline code / math or an unmatched opening tag is found first
+  const findEndOfBlockChild = (children: Token[]): number => {
+    const lastIndex = children.length - 1;
+
+    if (lastIndex >= 0) {
+      const lastChild = children[lastIndex];
+
+      // Fast path: no tokens were appended after the attribute text
+      if (lastChild.type === "text" && !isWhitespaceOnly(lastChild.content)) return lastIndex;
+    }
+
+    let depth = 0;
+
+    for (let index = lastIndex; index >= 0; index--) {
+      const child = children[index];
+
+      if (child.type === "code_inline" || child.type === "math_inline") return -1;
+
+      // A closing tag enters a nested structure while scanning backwards
+      if (child.nesting === -1) {
+        depth++;
+        continue;
+      }
+
+      // An opening tag leaves it; bail out on unmatched ones
+      if (child.nesting === 1 && --depth < 0) return -1;
+
+      // Skip nested, non-text and whitespace-only children
+      if (depth > 0 || child.type !== "text" || isWhitespaceOnly(child.content)) continue;
+
+      return index;
+    }
+
+    return -1;
+  };
 
   /** End of {.block} */
   return defineAttrRule({
@@ -15,29 +64,25 @@ export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): At
       {
         shift: 0,
         type: "inline",
-        children: [
-          {
-            position: -1,
-            content: createDelimiterChecker(options, "end"),
-            type: (type) => type !== "code_inline" && type !== "math_inline",
-          },
-        ],
+        children: (children): DelimiterRange | false => {
+          const childIndex = findEndOfBlockChild(children);
+
+          return childIndex === -1 ? false : endDelimiterChecker(children[childIndex].content);
+        },
       },
     ],
-    transform: (tokens, index, childIndex, range): void => {
-      const attrStartIndex = range[0] - options.left.length;
+    transform: (tokens, index, _, range): void => {
       // oxlint-disable-next-line typescript/no-non-null-assertion
-      const token = tokens[index].children![childIndex];
+      const children = tokens[index].children!;
+      const token = children[findEndOfBlockChild(children)];
+      const attrStartIndex = range[0] - options.left.length;
       const { content } = token;
       const hasTrailingSpace = isSpace(content.charCodeAt(attrStartIndex - 1));
 
-      // Find the closing token by skipping all nested closing tokens
-      let closingTokenIndex = index + 1;
-
-      while (tokens[closingTokenIndex + 1]?.nesting === -1) closingTokenIndex++;
-
-      // Get the corresponding opening token
-      const openingToken = getMatchingOpeningToken(tokens, closingTokenIndex);
+      // Get the corresponding opening token of the innermost wrapper - its
+      // closing token sits right after the inline token (unlike the softbreak
+      // rule, this never climbs to an outer ancestor)
+      const openingToken = getMatchingOpeningToken(tokens, index + 1);
 
       // Apply attributes to the opening token
       addAttrs(openingToken, content, range, options.allowed);

--- a/packages/plugin-attrs/src/rules/types.ts
+++ b/packages/plugin-attrs/src/rules/types.ts
@@ -29,11 +29,12 @@ export type TokenPropTest = {
  */
 interface BaseAttrRuleSet extends Omit<TokenPropTest, "children"> {
   /**
-   * 子规则集合，用于递归匹配
+   * 子规则集合，用于递归匹配；或一个自定义检查函数，可返回匹配到的分隔符范围
    *
-   * Child rule sets for recursive matching
+   * Child rule sets for recursive matching, or a custom checker function which may return the
+   * matched delimiter range
    */
-  children?: AttrRuleSet[] | TestFunction<Token[]>;
+  children?: AttrRuleSet[] | ((children: Token[]) => DelimiterRange | boolean);
 }
 
 /**


### PR DESCRIPTION
Porting markdown-it-attrs' [test suite](https://github.com/arve0/markdown-it-attrs/blob/master/test.js) surfaced four behavioral gaps in `@mdit/plugin-attrs`. Per review, this PR is now trimmed to just those fixes, with regression tests in the existing spec files. Follow-up PRs cover the ported suite, the opt-in `tasklist` rule, and the docs fixes.

### Core rule loop desync (crash + skipped rules)

A transform that splices tokens before the current position (the table calculate rule removing span-covered cells) shifted the stream under the scanner, so the tokens that moved into its place were skipped: the attrs paragraph after a table with spans stayed literal, and a second span table after it crashed with `TypeError: Cannot read properties of null (reading 'columnCount')`. The loop now re-locates the current token by identity after each transform. (markdown-it-attrs never hits this because its calculate rule hides covered cells instead of splicing them.)

### End-of-block attributes inside containers

The `blockEnd` transform walked past consecutive closing tokens to the outermost one, so with `@mdit/plugin-container` an end-of-block attribute inside the container leaked onto the container instead of the inner paragraph. It now targets the innermost wrapper (the closing token right after the inline token), matching markdown-it-attrs. Softbreak attributes keep targeting the outer block as before.

### Attributes hidden by appended inline tokens

The end-of-block rule only inspected the last inline child, so a heading-anchor style plugin registered before the attrs rule (appending permalink tokens after the heading text) broke `## Heading {#id}`. This ports markdown-it-attrs' `endOfBlockSearch`: scan the children backwards for the last meaningful text child, skipping whitespace-only text and balanced inline tag pairs, bailing on inline code/math and unmatched opening tags. `AttrRuleSet["children"]` now also accepts a checker function returning the delimiter range to support this.

### Quote-aware delimiter detection

`text {.replace-me data-tex="e^{i}=-1"}` failed end-detection because the checker used plain `lastIndexOf`/`indexOf`. The `start`/`end` checkers now skip delimiters inside (unescaped) quoted values, like markdown-it-attrs — falling back to the native searches when the content contains no quotes at all.

---

All fixes have regression tests in the package's own specs (`rules/blockEnd`, `rules/table`, `helper/getDelimiterChecker`, plus a small `simulatedPlugins.ts` helper for the token-appending scenarios), keeping `src` coverage at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
