### PR TITLE
docs(plugin-anchor): fix permalink builder imports

### DIFF
--- a/docs/src/anchor.md
+++ b/docs/src/anchor.md
@@ -136,7 +136,7 @@ Simple and accessible out of the box. The caveat is that you cannot
 include links inside headings.
 
 ```ts
-import { headerLink } from "@mdit/plugin-anchor/permalink";
+import { headerLink } from "@mdit/plugin-anchor";
 ```
 
 **Output:** `<h2 id="title"><a href="#title">Title</a></h2>`
@@ -151,7 +151,7 @@ import { headerLink } from "@mdit/plugin-anchor/permalink";
 Inserts a permalink anchor inside the heading, after or before the text.
 
 ```ts
-import { linkInsideHeader } from "@mdit/plugin-anchor/permalink";
+import { linkInsideHeader } from "@mdit/plugin-anchor";
 ```
 
 **Output:** `<h2 id="title">Title <a href="#title">#</a></h2>`
@@ -176,7 +176,7 @@ as `symbol`.
 Alias for `linkInsideHeader` with `ariaHidden: true` by default.
 
 ```ts
-import { ariaHidden } from "@mdit/plugin-anchor/permalink";
+import { ariaHidden } from "@mdit/plugin-anchor";
 ```
 
 **Output:** `<h2 id="title">Title <a href="#title" aria-hidden="true">#</a></h2>`
@@ -187,7 +187,7 @@ Places a permalink anchor **after** the heading block. Offers the most
 flexibility for accessible screen reader experiences.
 
 ```ts
-import { linkAfterHeader } from "@mdit/plugin-anchor/permalink";
+import { linkAfterHeader } from "@mdit/plugin-anchor";
 ```
 
 **Output:** `<h2 id="title">Title</h2><a href="#title"><span class="sr-only">Permalink</span> <span aria-hidden="true">#</span></a>`

--- a/docs/src/zh/anchor.md
+++ b/docs/src/zh/anchor.md
@@ -134,7 +134,7 @@ Anchor 插件会复用已有的 `id`。
 简单且开箱即用的无障碍方案。缺点是无法在标题中包含链接。
 
 ```ts
-import { headerLink } from "@mdit/plugin-anchor/permalink";
+import { headerLink } from "@mdit/plugin-anchor";
 ```
 
 **输出：** `<h2 id="title"><a href="#title">标题</a></h2>`
@@ -149,7 +149,7 @@ import { headerLink } from "@mdit/plugin-anchor/permalink";
 在标题内部插入永久链接锚点，位于文本之后或之前。
 
 ```ts
-import { linkInsideHeader } from "@mdit/plugin-anchor/permalink";
+import { linkInsideHeader } from "@mdit/plugin-anchor";
 ```
 
 **输出：** `<h2 id="title">标题 <a href="#title">#</a></h2>`
@@ -173,7 +173,7 @@ import { linkInsideHeader } from "@mdit/plugin-anchor/permalink";
 `linkInsideHeader` 的别名，默认 `ariaHidden: true`。
 
 ```ts
-import { ariaHidden } from "@mdit/plugin-anchor/permalink";
+import { ariaHidden } from "@mdit/plugin-anchor";
 ```
 
 **输出：** `<h2 id="title">标题 <a href="#title" aria-hidden="true">#</a></h2>`
@@ -183,7 +183,7 @@ import { ariaHidden } from "@mdit/plugin-anchor/permalink";
 在标题块**之后**放置永久链接锚点。提供最灵活的屏幕阅读器无障碍体验。
 
 ```ts
-import { linkAfterHeader } from "@mdit/plugin-anchor/permalink";
+import { linkAfterHeader } from "@mdit/plugin-anchor";
 ```
 
 **输出：** `<h2 id="title">标题</h2><a href="#title"><span class="sr-only">永久链接</span> <span aria-hidden="true">#</span></a>`


### PR DESCRIPTION
### Problem

The anchor docs instruct importing the permalink builders from a `permalink` subpath in four places each (en + zh — `headerLink`, `linkInsideHeader`, `ariaHidden`, `linkAfterHeader`):

```ts
import { headerLink } from "@mdit/plugin-anchor/permalink";
```

but the package's `exports` map has no such subpath, so following the docs fails:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './permalink' is not defined by "exports"
```

### Fix

Per review, this corrects the docs instead of adding a subpath export: the eight import examples now use the package root, where the builders are already exported (and tree-shaken when unused). No package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
