### PR TITLE
test(plugin-anchor): cover markdown-it-anchor suite gaps

### DIFF
--- a/packages/plugin-anchor/__tests__/basic.spec.ts
+++ b/packages/plugin-anchor/__tests__/basic.spec.ts
@@ -19,6 +19,12 @@ describe("basic functionality", () => {
     );
   });
 
+  it("should add anchors to setext headings", () => {
+    expect(md().render("First\n=====\n\nSecond\n------")).toBe(
+      '<h1 id="first" tabindex="-1">First</h1>\n<h2 id="second" tabindex="-1">Second</h2>\n',
+    );
+  });
+
   it("should slugify nested inline elements", () => {
     expect(
       md().render(
@@ -74,6 +80,15 @@ describe("slug options", () => {
     expect(mdInstance.render("# bar", { docId: "foo" })).toBe(
       '<h1 id="foo-bar" tabindex="-1">bar</h1>\n',
     );
+  });
+
+  it("should prefer slugifyWithState over slugify", () => {
+    expect(
+      md({
+        slugify: (): string => "from-slugify",
+        slugifyWithState: (title: string): string => `with-state-${title.toLowerCase()}`,
+      }).render("# Bar"),
+    ).toBe('<h1 id="with-state-bar" tabindex="-1">Bar</h1>\n');
   });
 });
 
@@ -159,6 +174,31 @@ describe("attrs integration", () => {
   it("should deduplicate when user id conflicts with auto slug", () => {
     expect(mdWithAttrs().render("# H1 {id=h2}\n\n## H2")).toBe(
       '<h1 id="h2" tabindex="-1">H1</h1>\n<h2 id="h2-1" tabindex="-1">H2</h2>\n',
+    );
+  });
+
+  it("should throw when a user id duplicates an earlier auto slug", () => {
+    expect(() => {
+      mdWithAttrs().render("# H1\n\n## H2 {id=h1}");
+    }).toThrow(
+      `User defined "id" attribute "h1" is not unique. Please fix it in your Markdown to continue.`,
+    );
+  });
+});
+
+describe("legacy options", () => {
+  it("should ignore markdown-it-anchor legacy permalink options", () => {
+    // The pre-9.x option surface was dropped intentionally - it must be
+    // ignored entirely instead of partially applied
+    const legacyOptions: Record<string, unknown> = {
+      permalink: true,
+      permalinkClass: "legacy-anchor",
+      permalinkSymbol: "¶",
+      renderPermalink: (): void => {},
+    };
+
+    expect(md(legacyOptions as AnchorOptions).render("# H1")).toBe(
+      '<h1 id="h1" tabindex="-1">H1</h1>\n',
     );
   });
 });

--- a/packages/plugin-anchor/__tests__/basic.spec.ts
+++ b/packages/plugin-anchor/__tests__/basic.spec.ts
@@ -85,7 +85,9 @@ describe("slug options", () => {
   it("should prefer slugifyWithState over slugify", () => {
     expect(
       md({
-        slugify: (): string => "from-slugify",
+        slugify: (): never => {
+          throw new Error("slugify should not be called");
+        },
         slugifyWithState: (title: string): string => `with-state-${title.toLowerCase()}`,
       }).render("# Bar"),
     ).toBe('<h1 id="with-state-bar" tabindex="-1">Bar</h1>\n');
@@ -194,7 +196,9 @@ describe("legacy options", () => {
       permalink: true,
       permalinkClass: "legacy-anchor",
       permalinkSymbol: "¶",
-      renderPermalink: (): void => {},
+      renderPermalink: (): never => {
+        throw new Error("legacy renderPermalink should not be called");
+      },
     };
 
     expect(md(legacyOptions as AnchorOptions).render("# H1")).toBe(

--- a/packages/plugin-anchor/__tests__/permalink-linkAfterHeader.spec.ts
+++ b/packages/plugin-anchor/__tests__/permalink-linkAfterHeader.spec.ts
@@ -1,6 +1,7 @@
 import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
+import type { PermalinkGenerator } from "../src/permalink/index.js";
 import { linkAfterHeader } from "../src/permalink/index.js";
 import { anchor } from "../src/plugin.js";
 
@@ -92,6 +93,16 @@ describe("permalink.linkAfterHeader", () => {
     );
   });
 
+  it("should render aria-labelledby style", () => {
+    expect(
+      md({
+        permalink: linkAfterHeader({ style: "aria-labelledby" }),
+      }).render("# H1"),
+    ).toBe(
+      '<h1 id="h1" tabindex="-1">H1</h1>\n<a class="header-anchor" href="#h1" aria-labelledby="h1">#</a>',
+    );
+  });
+
   it("should render with custom symbol and no text heading", () => {
     expect(
       md({
@@ -157,6 +168,50 @@ describe("permalink.linkAfterHeader", () => {
       }).render("# H1"),
     ).toBe(
       '<h1 id="h1" tabindex="-1">H1</h1>\n<a class="header-anchor" href="#h1" target="_blank"><span class="visually-hidden">Permalink to \u201CH1\u201D</span> <span aria-hidden="true"><i class="icon"></i></span></a>',
+    );
+  });
+
+  it("should render with custom renderHref", () => {
+    expect(
+      md({
+        permalink: linkAfterHeader({
+          ...opts,
+          renderHref: (slug: string): string => `/docs#${slug}`,
+        }),
+      }).render("# H1"),
+    ).toBe(
+      '<h1 id="h1" tabindex="-1">H1</h1>\n<a class="header-anchor" href="/docs#h1"><span class="visually-hidden">Permalink to \u201CH1\u201D</span> <span aria-hidden="true"><i class="icon"></i></span></a>',
+    );
+  });
+
+  it("should support a composed permalink with a shifted index", () => {
+    const renderLink = linkAfterHeader({
+      style: "visually-hidden",
+      assistiveText: (title: string): string => `Permalink to \u201C${title}\u201D`,
+      visuallyHiddenClass: "visually-hidden",
+    });
+    // Splices a wrapper around the heading before delegating, so the heading
+    // index the delegate receives is shifted by the wrapper's opening token
+    const wrapped: PermalinkGenerator = (slug, anchorOptions, state, idx) => {
+      state.tokens.splice(
+        idx,
+        0,
+        Object.assign(new state.Token("div_open", "div", 1), {
+          attrs: [["class", "wrapper"]],
+          block: true,
+        }),
+      );
+      state.tokens.splice(
+        idx + 4,
+        0,
+        Object.assign(new state.Token("div_close", "div", -1), { block: true }),
+      );
+
+      renderLink(slug, anchorOptions, state, idx + 1);
+    };
+
+    expect(md({ permalink: wrapped }).render("# H1")).toBe(
+      '<div class="wrapper">\n<h1 id="h1" tabindex="-1">H1</h1>\n<a class="header-anchor" href="#h1"><span class="visually-hidden">Permalink to \u201CH1\u201D</span> <span aria-hidden="true">#</span></a></div>\n',
     );
   });
 });

--- a/packages/plugin-anchor/__tests__/permalink-linkInsideHeader.spec.ts
+++ b/packages/plugin-anchor/__tests__/permalink-linkInsideHeader.spec.ts
@@ -26,6 +26,20 @@ describe("permalink.linkInsideHeader", () => {
     );
   });
 
+  it("should mark the symbol token with isPermalinkSymbol meta", () => {
+    // Downstream heading collectors (e.g. toc extraction) rely on this meta to
+    // exclude the symbol from heading texts
+    const symbolToken = md({ permalink: linkInsideHeader() })
+      .parse("# H1", {})
+      .find((token) => token.type === "inline")
+      ?.children?.find(
+        (token) => (token.meta as Record<string, unknown> | null)?.isPermalinkSymbol === true,
+      );
+
+    expect(symbolToken?.type).toBe("html_inline");
+    expect(symbolToken?.content).toBe("#");
+  });
+
   it("should render with HTML symbol and placement before", () => {
     const symbol =
       '<span class="visually-hidden">Jump to heading</span> <span aria-hidden="true">#</span>';


### PR DESCRIPTION
### What

Test-only additions to `plugin-anchor` covering behaviors that `markdown-it-anchor`'s own suite locks down but this package's suite did not. Every behavior already matches `markdown-it-anchor@9.2.1` (verified via a differential run of its full suite against this plugin) — these tests just pin them so future refactors can't silently regress:

- **Setext headings** get ids like ATX headings.
- **`slugifyWithState` wins over `slugify`** when both are provided.
- **A user-defined id colliding with an earlier auto slug throws** — the suite only covered the reverse direction (`# H1 {id=h2}` before `## H2`) and same-user-id duplicates.
- **Legacy markdown-it-anchor options** (`permalink: true`, `permalinkClass`, `permalinkSymbol`, `renderPermalink`) are ignored entirely rather than partially applied — locks in the intentional break.
- **Composed permalink with a shifted index** (port of markdown-it-anchor's "custom splice wrapper" test): a user permalink fn wraps `linkAfterHeader`, splices a wrapper around the heading, and delegates with `idx + 1` — exercises the post-mutation token resync.
- **`linkAfterHeader` with `style: "aria-labelledby"`** — previously untested (in markdown-it-anchor too).
- **`linkAfterHeader` with custom `renderHref`** — previously only tested for `linkInsideHeader`/`headerLink`.
- **The permalink symbol token carries `meta.isPermalinkSymbol`** as an `html_inline` token — downstream heading/toc collectors (e.g. VitePress via @mdit-vue) rely on this meta to exclude the symbol from heading texts, and no test asserted it.

### Notes

- No source changes; coverage stays 100%.
- 8 new tests; suite goes 48 → 56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
