### PR TITLE
docs(plugin-attrs): fix image example and demo notes

### DIFF
--- a/docs/src/attrs.md
+++ b/docs/src/attrs.md
@@ -33,7 +33,7 @@ For example, if you want a heading2 "Hello World" with a id "say-hello-world", y
 If you want a image with class "full-width", you can write:
 
 ```md
-![img](link/to/image.png) {.full-width}
+![img](link/to/image.png){.full-width}
 ```
 
 Also, other attrs are supported, so:
@@ -116,7 +116,7 @@ type MarkdownItAttrRuleName =
 
 ## Demo
 
-> ALl class are styled with `margin: 4px;padding: 4px;border: 1px solid red;` to show the effect.
+> All classes are styled with `margin: 4px;padding: 4px;border: 1px solid red;` to show the effect.
 
 ::: preview Inline
 
@@ -137,6 +137,8 @@ const a = 1;
 ```
 
 :::
+
+> No red border here: the syntax highlighter used by these docs replaces the fence renderer and drops the attributes, as most code highlighting setups do.
 
 ::: preview Table
 

--- a/docs/src/zh/attrs.md
+++ b/docs/src/zh/attrs.md
@@ -33,7 +33,7 @@ mdIt.render("# Heading 🎉{#heading}");
 如果你想要一个有 full-width Class 的图片，你可以使用:
 
 ```md
-![img](link/to/image.png) {.full-width}
+![img](link/to/image.png){.full-width}
 ```
 
 同时，其他属性也收到支持:
@@ -135,6 +135,8 @@ const a = 1;
 ```
 
 :::
+
+> 此处没有红色边框：文档使用的语法高亮会替换 fence 渲染器并丢弃这些属性，大多数代码高亮方案都是如此。
 
 ::: preview 表格
 


### PR DESCRIPTION
Docs-only fixes split out of #575 per review:

- The image example used `![img](link/to/image.png) {.full-width}` — with the space that's end-of-block syntax and the class lands on the paragraph, not the image. Removed the space (en + zh).
- Fixed the casing/grammar of the demo styling note.
- Added a note to the Fence demo (en + zh): the docs' syntax highlighter replaces the fence renderer and drops the attributes, as most highlighting setups do, so that demo cannot show a red border here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
