### PR TITLE
feat(plugin-attrs): add opt-in tasklist rule

### DIFF
--- a/docs/src/attrs.md
+++ b/docs/src/attrs.md
@@ -84,7 +84,9 @@ type MarkdownItAttrRuleName =
   | "blockInfo"
   | "blockEnd"
   // legacy alias of "blockEnd"
-  | "block";
+  | "block"
+  // opt-in, excluded from "all"
+  | "tasklist";
 ```
 
 - Default: `"all"`
@@ -95,6 +97,8 @@ type MarkdownItAttrRuleName =
   If you only need id attrs for headings (for most cases), you shall set `rule: ["heading"]` to only enable attrs for headings.
 
   The `fence` rule only applies to fenced code blocks, while the `blockInfo` rule covers other block tokens carrying attributes on their info line (e.g.: containers from `@mdit/plugin-container`). The `blockEnd` rule applies attributes written at the end of a block element - `block` is its legacy alias.
+
+  The `tasklist` rule supports task list plugins that wrap item contents in a label (e.g. `@mdit/plugin-tasklist`). Task lists are not part of core markdown-it, so this rule must be enabled explicitly in the rule array and is excluded from `"all"`.
 
 ### allowed
 

--- a/docs/src/zh/attrs.md
+++ b/docs/src/zh/attrs.md
@@ -82,7 +82,9 @@ type MarkdownItAttrRuleName =
   | "blockInfo"
   | "blockEnd"
   // legacy alias of "blockEnd"
-  | "block";
+  | "block"
+  // opt-in, excluded from "all"
+  | "tasklist";
 ```
 
 - 默认值：`"all"`
@@ -93,6 +95,8 @@ type MarkdownItAttrRuleName =
   如果你只需要为标题添加 id 属性（在大多数情况下），你应该设置 `rule: ["heading"]` 来只为标题启用属性功能。
 
   `fence` 规则仅作用于代码块，而 `blockInfo` 规则作用于其他在信息行上携带属性的块级 token（例如 `@mdit/plugin-container` 的容器）。`blockEnd` 规则作用于写在块级元素末尾的属性，`block` 是它的旧别名。
+
+  `tasklist` 规则为将列表项内容包裹在 label 中的任务列表插件（例如 `@mdit/plugin-tasklist`）提供属性支持。任务列表不属于 markdown-it 核心语法，因此该规则需要在规则数组中显式启用，不包含在 `"all"` 中。
 
 ### allowed
 

--- a/packages/plugin-attrs/__tests__/rules/tasklist.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/tasklist.spec.ts
@@ -1,0 +1,93 @@
+import { tasklist } from "@mdit/plugin-tasklist";
+import MarkdownIt from "markdown-it";
+import { describe, expect, it } from "vitest";
+
+import { attrs } from "../../src/index.js";
+
+describe("tasklist rule", () => {
+  const markdownIt = MarkdownIt()
+    .use(attrs, { rule: ["list", "tasklist"] })
+    .use(tasklist);
+
+  it("should stay disabled by default", () => {
+    const markdownItDefault = MarkdownIt().use(attrs).use(tasklist);
+    const expected = `\
+<ul class="task-list-container">
+<li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" disabled="disabled"><label class="task-list-item-label" for="task-item-0"> foo {.red}</label></li>
+</ul>
+`;
+
+    expect(markdownItDefault.render("- [ ] foo {.red}")).toBe(expected);
+  });
+
+  it("should apply attributes to task list items wrapped in labels", () => {
+    const src = "- [ ] foo {.red}\n- [x] done {#did}";
+    const expected = `\
+<ul class="task-list-container">
+<li class="task-list-item red"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" disabled="disabled"><label class="task-list-item-label" for="task-item-0"> foo</label></li>
+<li class="task-list-item" id="did"><input type="checkbox" class="task-list-item-checkbox" id="task-item-1" checked="checked" disabled="disabled"><label class="task-list-item-label" for="task-item-1"> done</label></li>
+</ul>
+`;
+
+    expect(markdownIt.render(src)).toBe(expected);
+  });
+
+  it("should support attributes without a leading space", () => {
+    const src = "- [ ] foo{.red}";
+    const expected = `\
+<ul class="task-list-container">
+<li class="task-list-item red"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" disabled="disabled"><label class="task-list-item-label" for="task-item-0"> foo</label></li>
+</ul>
+`;
+
+    expect(markdownIt.render(src)).toBe(expected);
+  });
+
+  it("should apply attributes after a softbreak to the task list", () => {
+    const src = "- [ ] foo\n- [ ] bar\n{.fancy}";
+    const expected = `\
+<ul class="task-list-container fancy">
+<li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" disabled="disabled"><label class="task-list-item-label" for="task-item-0"> foo</label></li>
+<li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" id="task-item-1" disabled="disabled"><label class="task-list-item-label" for="task-item-1"> bar</label></li>
+</ul>
+`;
+
+    expect(markdownIt.render(src)).toBe(expected);
+  });
+
+  it("should support ordered task lists", () => {
+    const src = "1. [x] foo {.red}";
+    const expected = `\
+<ol class="task-list-container">
+<li class="task-list-item red"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" checked="checked" disabled="disabled"><label class="task-list-item-label" for="task-item-0"> foo</label></li>
+</ol>
+`;
+
+    expect(markdownIt.render(src)).toBe(expected);
+  });
+
+  it("should leave attributes inside nested inline tokens untouched", () => {
+    const src = "- [ ] *foo {.red}*";
+    const expected = `\
+<ul class="task-list-container">
+<li class="task-list-item"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" disabled="disabled"><label class="task-list-item-label" for="task-item-0"> <em>foo {.red}</em></label></li>
+</ul>
+`;
+
+    expect(markdownIt.render(src)).toBe(expected);
+  });
+
+  it("should apply attributes to task list items without labels", () => {
+    const markdownItNoLabel = MarkdownIt()
+      .use(attrs, { rule: ["list", "tasklist"] })
+      .use(tasklist, { label: false });
+    const src = "- [ ] foo {.red}";
+    const expected = `\
+<ul class="task-list-container">
+<li class="task-list-item red"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" disabled="disabled"> foo</li>
+</ul>
+`;
+
+    expect(markdownItNoLabel.render(src)).toBe(expected);
+  });
+});

--- a/packages/plugin-attrs/package.json
+++ b/packages/plugin-attrs/package.json
@@ -51,7 +51,8 @@
     "@mdit/plugin-container": "workspace:*",
     "@mdit/plugin-figure": "workspace:*",
     "@mdit/plugin-katex": "workspace:*",
-    "@mdit/plugin-mark": "workspace:*"
+    "@mdit/plugin-mark": "workspace:*",
+    "@mdit/plugin-tasklist": "workspace:*"
   },
   "peerDependencies": {
     "markdown-it": "^14.2.0"

--- a/packages/plugin-attrs/src/options.ts
+++ b/packages/plugin-attrs/src/options.ts
@@ -11,7 +11,9 @@ export type MarkdownItAttrRuleName =
   | "blockInfo"
   | "blockEnd"
   /** Legacy alias of `blockEnd` */
-  | "block";
+  | "block"
+  /** Opt-in task list label support - excluded from `"all"` */
+  | "tasklist";
 
 export interface MarkdownItAttrsOptions extends Partial<DelimiterConfig> {
   /**

--- a/packages/plugin-attrs/src/rules/rules.ts
+++ b/packages/plugin-attrs/src/rules/rules.ts
@@ -10,6 +10,7 @@ import { createInlineRules } from "./inline.js";
 import { createListRules } from "./list.js";
 import { createSoftBreakRule } from "./softbreak.js";
 import { createTableRules } from "./table.js";
+import { createTasklistRules } from "./tasklist.js";
 import type { AttrRule } from "./types.js";
 
 const AVAILABLE_RULES: MarkdownItAttrRuleName[] = [
@@ -25,6 +26,9 @@ const AVAILABLE_RULES: MarkdownItAttrRuleName[] = [
   "block",
 ];
 
+// Opt-in rules for third-party plugin interop - excluded from "all"
+const EXTENSION_RULES = new Set<MarkdownItAttrRuleName>(["tasklist"]);
+
 export const createRules = (
   md: MarkdownIt,
   options: Required<MarkdownItAttrsOptions>,
@@ -35,7 +39,7 @@ export const createRules = (
       ? []
       : Array.isArray(options.rule)
         ? // user specific rules
-          options.rule.filter((item) => AVAILABLE_RULES.includes(item))
+          options.rule.filter((item) => AVAILABLE_RULES.includes(item) || EXTENSION_RULES.has(item))
         : AVAILABLE_RULES;
 
   const rules: AttrRule[] = [];
@@ -44,6 +48,7 @@ export const createRules = (
   if (enabledRules.includes("inline")) rules.push(...createInlineRules(options));
   if (enabledRules.includes("table")) rules.push(...createTableRules(md, options));
   if (enabledRules.includes("list")) rules.push(...createListRules(md, options));
+  if (enabledRules.includes("tasklist")) rules.push(...createTasklistRules(md, options));
   if (enabledRules.includes("softbreak")) rules.push(createSoftBreakRule(options));
   if (enabledRules.includes("hr")) rules.push(createHrRule(md, options));
   if (enabledRules.includes("blockInfo")) rules.push(createBlockInfoRule(md, options));

--- a/packages/plugin-attrs/src/rules/tasklist.ts
+++ b/packages/plugin-attrs/src/rules/tasklist.ts
@@ -1,0 +1,107 @@
+import type MarkdownIt from "markdown-it";
+
+import type { DelimiterConfig } from "../helper/index.js";
+import { addAttrs, createDelimiterChecker } from "../helper/index.js";
+import type { AttrRule } from "./types.js";
+import { defineAttrRule } from "./types.js";
+
+// List rules for task list plugins that wrap item contents in a label (e.g.
+// @mdit/plugin-tasklist): the trailing label closing token hides the attribute
+// text from the standard list rules
+export const createTasklistRules = (md: MarkdownIt, options: DelimiterConfig): AttrRule[] => {
+  const isSpace = md.utils.isSpace;
+  const allowed = options.allowed;
+
+  return [
+    /** - Task \n {.a} */
+    defineAttrRule({
+      name: "tasklist softbreak",
+      tests: [
+        {
+          shift: -2,
+          type: "list_item_open",
+        },
+        {
+          shift: 0,
+          type: "inline",
+          children: [
+            {
+              position: -3,
+              type: "softbreak",
+            },
+            {
+              position: -2,
+              type: "text",
+              content: createDelimiterChecker(options, "only"),
+            },
+            {
+              position: -1,
+              type: "label_close",
+            },
+          ],
+        },
+      ],
+      transform: (tokens, index, childIndex, range): void => {
+        // childIndex points at label_close - the attribute text sits before it
+        // oxlint-disable-next-line typescript/no-non-null-assertion
+        const childTokens = tokens[index].children!;
+        const token = childTokens[childIndex - 1];
+
+        let listOpenIndex = index - 2;
+
+        // Find the list opening token
+        while (
+          tokens[listOpenIndex - 1].type !== "ordered_list_open" &&
+          tokens[listOpenIndex - 1].type !== "bullet_list_open"
+        )
+          listOpenIndex--;
+
+        // Apply attributes to the list opening token
+        addAttrs(tokens[listOpenIndex - 1], token.content, range, allowed);
+
+        // Remove the attribute tokens from inside the label
+        childTokens.splice(childIndex - 2, 2);
+      },
+    }),
+
+    /** - End of {.task-item} */
+    defineAttrRule({
+      name: "tasklist item end",
+      tests: [
+        {
+          shift: -2,
+          type: "list_item_open",
+        },
+        {
+          shift: 0,
+          type: "inline",
+          children: [
+            {
+              position: -2,
+              type: "text",
+              content: createDelimiterChecker(options, "end"),
+            },
+            {
+              position: -1,
+              type: "label_close",
+            },
+          ],
+        },
+      ],
+      transform: (tokens, index, childIndex, range): void => {
+        // childIndex points at label_close - the attribute text sits before it
+        // oxlint-disable-next-line typescript/no-non-null-assertion
+        const token = tokens[index].children![childIndex - 1];
+        const content = token.content;
+        const attrStartIndex = range[0] - options.left.length;
+        const hasTrailingSpace = isSpace(content.charCodeAt(attrStartIndex - 1));
+
+        // Apply attributes to the list item opening token
+        addAttrs(tokens[index - 2], content, range, allowed);
+
+        // Remove attribute syntax from content
+        token.content = content.slice(0, hasTrailingSpace ? attrStartIndex - 1 : attrStartIndex);
+      },
+    }),
+  ];
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -458,6 +458,9 @@ importers:
       '@mdit/plugin-mark':
         specifier: workspace:*
         version: link:../plugin-mark
+      '@mdit/plugin-tasklist':
+        specifier: workspace:*
+        version: link:../plugin-tasklist
 
   packages/plugin-container:
     dependencies:


### PR DESCRIPTION
Split out of #575 per review, redesigned as requested there: task list support is now a separate named rule, not enabled by default.

### Problem

Task list plugins that wrap item contents in a label (e.g. `@mdit/plugin-tasklist` with its default `label` option) append `label_close` as the last inline child, so the list rules never match and both item-level and list-level attribute text renders literally:

```md
- [ ] foo {.custom}
- [x] bar
{.fancy}
```

### Design

- New `tasklist` rule (`src/rules/tasklist.ts`): label-aware variants of the two list rules that accept the attribute text directly before a trailing `label_close`. Classes merge with the task list plugin's own (`class="task-list-item custom"`).
- Opt-in only: task lists are not core markdown-it syntax, so the rule must be listed explicitly in the `rule` array and is excluded from `"all"` (kept out of `AVAILABLE_RULES`; arrays are additionally filtered against an extension set).
- Tests use the real `@mdit/plugin-tasklist` (new devDependency), including a default-config test proving the rule stays off, the `label: false` path through the standard list rules, and attributes inside nested inline tokens staying literal. Coverage stays 100%.

Happy to follow up with support for other wrappers like `@mdit/plugin-dl` on the same opt-in basis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
