### PR TITLE
test(plugin-attrs): port markdown-it-attrs suite gaps

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/inline.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/inline.spec.ts
@@ -88,6 +88,13 @@ const createDualRuleTests = (
 
         expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
       });
+
+      it(replaceDelimiters("should support empty quoted attrs", options), () => {
+        const src = '![](img.png){class="" height="100" width=""}';
+        const expected = '<p><img src="img.png" alt="" class="" height="100" width=""></p>\n';
+
+        expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
+      });
     });
   });
 };

--- a/packages/plugin-attrs/__tests__/rules/table.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/table.spec.ts
@@ -403,6 +403,70 @@ const createDualRuleTests = (
 </table>
 `,
           ],
+          // rowspan on a cell dropped by an occupied column should not register
+          [
+            `\
+| A | B | C |
+| -- | -- | -- |
+| 1 {rowspan=2}| 11 | 111 |
+| 2 {rowspan=2}| 22 | 222 |
+| 3 | 33 | 333 |
+`,
+            `\
+<table>
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+<th>C</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td rowspan="2">1</td>
+<td>11</td>
+<td>111</td>
+</tr>
+<tr>
+<td>22</td>
+<td>222</td>
+</tr>
+<tr>
+<td>3</td>
+<td>33</td>
+<td>333</td>
+</tr>
+</tbody>
+</table>
+`,
+          ],
+          // colspan on a cell merged by a preceding colspan should be ignored
+          [
+            `\
+| A | B | C | D |
+| -- | -- | -- | -- |
+| 1 {colspan=2}| 11 {colspan=3} | 111| 1111 |
+`,
+            `\
+<table>
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+<th>C</th>
+<th>D</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">1</td>
+<td>111</td>
+<td>1111</td>
+</tr>
+</tbody>
+</table>
+`,
+          ],
         ];
 
         testCases.forEach(([src, expected]) => {


### PR DESCRIPTION
Completes the review request to keep only necessary ported tests: the full markdown-it-attrs suite (54 cases across its basic/tables/plugins groups) was audited case-by-case against the existing specs, and everything is already pinned by them except three behaviors, added here to the existing files (standalone on main - they pass independently of the fix PRs):

- `rules/table.spec.ts` — two entries in the span-calculation cases: a rowspan on a cell dropped by an occupied column must not register in grid occupancy (its row would otherwise swallow a later cell), and a colspan on a cell merged away by a preceding colspan is ignored. Both sit exactly on the documented grid-reading divergence from markdown-it-attrs and on the splice-before-reading-attrs code paths in `table.ts`.
- `rules/inline.spec.ts` — explicitly empty quoted attribute values (`{class="" width=""}`) are preserved; existing tests only pinned empty values from a bare `key=`.

No `markdownItAttrs` folder — test file names stay constant per review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
