### PR TITLE
fix(plugin-attrs): resync the scanner after token splices

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/table.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/table.spec.ts
@@ -27,7 +27,6 @@ const createDualRuleTests = (
 | ------- | ------- |
 | cell1   | cell2   |
 
-
 {.class}`;
 
         const expected = `\
@@ -408,6 +407,106 @@ const createDualRuleTests = (
         testCases.forEach(([src, expected]) => {
           expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
         });
+      });
+
+      it(replaceDelimiters("should apply attributes after a table with spans", options), () => {
+        const src = `\
+| A                        | B   | C   | D              |
+| ------------------------ | --- | --- | -------------- |
+| A1                       | B1  | C1  | D1 {rowspan=3} |
+| A2 {colspan=2 rowspan=2} | B2  | C2  | D2             |
+| A3                       | B3  | C3  | D3             |
+
+{.table border=1}
+`;
+
+        const expected = `\
+<table class="table" border="1">
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+<th>C</th>
+<th>D</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>A1</td>
+<td>B1</td>
+<td>C1</td>
+<td rowspan="3">D1</td>
+</tr>
+<tr>
+<td colspan="2" rowspan="2">A2</td>
+<td>C2</td>
+</tr>
+<tr>
+<td>C3</td>
+</tr>
+</tbody>
+</table>
+`;
+
+        expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
+      });
+
+      it(replaceDelimiters("should support consecutive tables with spans", options), () => {
+        const src = `\
+| A                        | B   | C   | D              |
+| ------------------------ | --- | --- | -------------- |
+| A1                       | B1  | C1  | D1 {rowspan=3} |
+| A2 {colspan=2 rowspan=2} | B2  | C2  | D2             |
+| A3                       | B3  | C3  | D3             |
+
+{border=1}
+| E | F |
+| --- | --- |
+| E1 {colspan=2} |
+`;
+
+        const expected = `\
+<table border="1">
+<thead>
+<tr>
+<th>A</th>
+<th>B</th>
+<th>C</th>
+<th>D</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>A1</td>
+<td>B1</td>
+<td>C1</td>
+<td rowspan="3">D1</td>
+</tr>
+<tr>
+<td colspan="2" rowspan="2">A2</td>
+<td>C2</td>
+</tr>
+<tr>
+<td>C3</td>
+</tr>
+</tbody>
+</table>
+<table>
+<thead>
+<tr>
+<th>E</th>
+<th>F</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td colspan="2">E1</td>
+</tr>
+</tbody>
+</table>
+`;
+
+        expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
       });
 
       it(replaceDelimiters("should support empty inline tokens", options), () => {

--- a/packages/plugin-attrs/src/plugin.ts
+++ b/packages/plugin-attrs/src/plugin.ts
@@ -39,8 +39,14 @@ export const attrs: PluginWithOptions<MarkdownItAttrsOptions> = (
         });
 
         if (match) {
+          const currentToken = tokens[index];
+
           // oxlint-disable-next-line typescript/no-non-null-assertion
           pattern.transform(tokens, index, position!, range!);
+
+          // re-locate the current token in case the transform spliced tokens
+          // before it (e.g. the table calculate rule removing covered cells)
+          if (tokens[index] !== currentToken) index = tokens.indexOf(currentToken);
 
           if (
             pattern.name === "inline attributes" ||


### PR DESCRIPTION
Fix 1 of 4 split from #575 per review (one PR per issue).

### Problem

A transform that splices tokens before the current position shifts the token stream under the core rule scanner, so the tokens that move into its place are skipped. The table calculate rule does exactly that (it removes span-covered cells), so attributes following a table with spans stay literal:

```md
| A | B |
| - | - |
| 1 {colspan=2} | 2 |

{.striped}
```

renders the `{.striped}` paragraph as literal text instead of `<table class="striped">`. Worse, when a second table with spans follows, the skipped window swallows the `tr_close` / `thead_close` / `tbody_open` tokens the `table thead metadata` rule needs:

```
TypeError: Cannot read properties of null (reading 'columnCount')
```

### Fix

Re-locate the current token by identity after each transform. (markdown-it-attrs never hits this because its calculate rule hides covered cells instead of splicing them.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
