### PR TITLE
fix(plugin-attrs): target the innermost block wrapper

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
@@ -205,13 +205,13 @@ const createDualRuleTests = (
 
       it(
         replaceDelimiters(
-          "should handle nested block structures with multiple closing tokens",
+          "should apply attributes to the innermost block in nested structures",
           options,
         ),
         () => {
           const src = "> > nested blockquote {.nested}";
           const expected =
-            '<blockquote class="nested">\n<blockquote>\n<p>nested blockquote</p>\n</blockquote>\n</blockquote>\n';
+            '<blockquote>\n<blockquote>\n<p class="nested">nested blockquote</p>\n</blockquote>\n</blockquote>\n';
 
           expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
         },

--- a/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
@@ -1,3 +1,4 @@
+import { container } from "@mdit/plugin-container";
 import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
@@ -244,3 +245,14 @@ createDualRuleTests(
   },
   "with [[ ]] delimiters",
 );
+
+describe("end of block inside containers", () => {
+  it("should apply attributes to the inner paragraph, not the container", () => {
+    const markdownIt = MarkdownIt().use(attrs).use(container, { name: "column" });
+    const src = ":::column {.column-container}\n\ncolumn test1 {.column-1}\n\n:::\n";
+    const expected =
+      '<div class="column-container column">\n<p class="column-1">column test1</p>\n</div>\n';
+
+    expect(markdownIt.render(src)).toBe(expected);
+  });
+});

--- a/packages/plugin-attrs/src/rules/blockEnd.ts
+++ b/packages/plugin-attrs/src/rules/blockEnd.ts
@@ -31,13 +31,10 @@ export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): At
       const { content } = token;
       const hasTrailingSpace = isSpace(content.charCodeAt(attrStartIndex - 1));
 
-      // Find the closing token by skipping all nested closing tokens
-      let closingTokenIndex = index + 1;
-
-      while (tokens[closingTokenIndex + 1]?.nesting === -1) closingTokenIndex++;
-
-      // Get the corresponding opening token
-      const openingToken = getMatchingOpeningToken(tokens, closingTokenIndex);
+      // Get the corresponding opening token of the innermost wrapper - its
+      // closing token sits right after the inline token (unlike the softbreak
+      // rule, this never climbs to an outer ancestor)
+      const openingToken = getMatchingOpeningToken(tokens, index + 1);
 
       // Apply attributes to the opening token
       addAttrs(openingToken, content, range, options.allowed);


### PR DESCRIPTION
Fix 2 of 4 split from #575 per review (one PR per issue).

### Problem

The end-of-block transform walked past consecutive closing tokens to the outermost one, so an attribute inside a nested structure leaked onto the outer element. With `@mdit/plugin-container`:

```md
:::column {.column-container}

column test1 {.column-1}

:::
```

rendered `<div class="column-container column-1 column">` — the paragraph's class ended up on the container. Same for `> > nested blockquote {.nested}`, where the class landed on the outer blockquote.

### Fix

Target the innermost wrapper: the closing token right after the inline token. This matches markdown-it-attrs:

```html
<div class="column-container column">
<p class="column-1">column test1</p>
</div>
```

Softbreak attributes (`{.c}` on its own line after a block) keep targeting the outer block — that path goes through the softbreak rule, which is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
