### PR TITLE
fix(plugin-attrs): search past appended inline tokens

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
@@ -1,10 +1,16 @@
 import { container } from "@mdit/plugin-container";
+import { katex } from "@mdit/plugin-katex";
 import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
 import type { MarkdownItAttrsOptions } from "../../src/index.js";
 import { attrs } from "../../src/index.js";
 import { replaceDelimiters } from "../replaceDelimiters.js";
+import {
+  headingAnchorPlugin,
+  trailingSpacePlugin,
+  unmatchedOpenPlugin,
+} from "../simulatedPlugins.js";
 
 const createDualRuleTests = (
   baseOptions: MarkdownItAttrsOptions & { left: string; right: string },
@@ -254,5 +260,56 @@ describe("end of block inside containers", () => {
       '<div class="column-container column">\n<p class="column-1">column test1</p>\n</div>\n';
 
     expect(markdownIt.render(src)).toBe(expected);
+  });
+});
+
+describe("end of block child search", () => {
+  it("should find attrs before tokens appended by heading anchor style plugins", () => {
+    const markdownIt = MarkdownIt();
+
+    headingAnchorPlugin(markdownIt);
+    markdownIt.use(attrs);
+
+    expect(markdownIt.render("## H2 heading {#my-id}")).toBe(
+      '<h2 id="my-id">H2 heading <a href="#">#</a></h2>\n',
+    );
+  });
+
+  it("should skip trailing whitespace-only text children", () => {
+    const markdownIt = MarkdownIt();
+
+    trailingSpacePlugin(markdownIt);
+    markdownIt.use(attrs);
+
+    expect(markdownIt.render("text {.c}")).toBe('<p class="c">text </p>\n');
+  });
+
+  it("should skip trailing top level non-text tokens", () => {
+    const markdownIt = MarkdownIt({ html: true }).use(attrs);
+
+    expect(markdownIt.render("text {.c}<br>")).toBe('<p class="c">text<br></p>\n');
+  });
+
+  it("should not search past inline code", () => {
+    const markdownIt = MarkdownIt().use(attrs);
+
+    expect(markdownIt.render("text {.c}`code`")).toBe("<p>text {.c}<code>code</code></p>\n");
+  });
+
+  it("should not search past inline math", () => {
+    const markdownIt = MarkdownIt().use(attrs).use(katex);
+    const markdownItWithOnlyKatex = MarkdownIt().use(katex);
+    const src = "text {.c}$a$";
+
+    expect(markdownIt.render(src)).toBe(markdownItWithOnlyKatex.render(src));
+  });
+
+  it("should stop at unmatched opening tags", () => {
+    const markdownIt = MarkdownIt();
+
+    unmatchedOpenPlugin(markdownIt);
+    markdownIt.use(attrs);
+
+    expect(markdownIt.render("text {.c}")).toBe("<p>text {.c}<a></p>\n");
   });
 });

--- a/packages/plugin-attrs/__tests__/simulatedPlugins.ts
+++ b/packages/plugin-attrs/__tests__/simulatedPlugins.ts
@@ -1,0 +1,71 @@
+/**
+ * Simulated plugins that inject inline children before the attrs rule runs.
+ *
+ * They register with `md.core.ruler.before("linkify", ...)` so they run ahead of the attrs rule -
+ * real plugins with this ordering exist, but e.g. `@mdit/plugin-anchor` pushes its rule to the end
+ * of the core chain and runs after the attrs rule, so it cannot reproduce it.
+ */
+import type MarkdownIt from "markdown-it";
+
+/**
+ * Simulate a navigation / heading anchor plugin appending a permalink after the heading text, so
+ * the attribute text is no longer the last child of the inline token
+ *
+ * @param md - The markdown-it instance to install the rule on
+ */
+export const headingAnchorPlugin = (md: MarkdownIt): void => {
+  md.core.ruler.before("linkify", "heading_anchor_test", (state) => {
+    state.tokens.forEach((token, index) => {
+      if (token.type !== "heading_open") return;
+
+      const space = new state.Token("text", "", 0);
+
+      space.content = " ";
+
+      const anchorOpen = new state.Token("link_open", "a", 1);
+
+      anchorOpen.attrs = [["href", "#"]];
+
+      const anchorSymbol = new state.Token("html_inline", "", 0);
+
+      anchorSymbol.content = "#";
+
+      const anchorClose = new state.Token("link_close", "a", -1);
+
+      state.tokens[index + 1].children?.push(space, anchorOpen, anchorSymbol, anchorClose);
+    });
+  });
+};
+
+/**
+ * Simulate a plugin appending a whitespace-only text token after the attribute text
+ *
+ * @param md - The markdown-it instance to install the rule on
+ */
+export const trailingSpacePlugin = (md: MarkdownIt): void => {
+  md.core.ruler.before("linkify", "trailing_space_test", (state) => {
+    state.tokens.forEach((token) => {
+      if (token.type !== "inline") return;
+
+      const space = new state.Token("text", "", 0);
+
+      space.content = " ";
+      token.children?.push(space);
+    });
+  });
+};
+
+/**
+ * Simulate a plugin appending an opening tag without its closing counterpart
+ *
+ * @param md - The markdown-it instance to install the rule on
+ */
+export const unmatchedOpenPlugin = (md: MarkdownIt): void => {
+  md.core.ruler.before("linkify", "unmatched_open_test", (state) => {
+    state.tokens.forEach((token) => {
+      if (token.type !== "inline") return;
+
+      token.children?.push(new state.Token("link_open", "a", 1));
+    });
+  });
+};

--- a/packages/plugin-attrs/src/rules/blockEnd.ts
+++ b/packages/plugin-attrs/src/rules/blockEnd.ts
@@ -1,12 +1,61 @@
 import type MarkdownIt from "markdown-it";
+import type Token from "markdown-it/lib/token.mjs";
 
 import type { DelimiterConfig } from "../helper/index.js";
 import { addAttrs, createDelimiterChecker, getMatchingOpeningToken } from "../helper/index.js";
-import type { AttrRule } from "./types.js";
+import type { AttrRule, DelimiterRange } from "./types.js";
 import { defineAttrRule } from "./types.js";
 
 export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): AttrRule => {
   const isSpace = md.utils.isSpace;
+  const isWhiteSpace = md.utils.isWhiteSpace;
+  const endDelimiterChecker = createDelimiterChecker(options, "end");
+
+  // Non-allocating `content.trim() === ""`
+  const isWhitespaceOnly = (content: string): boolean => {
+    for (let index = 0; index < content.length; index++)
+      if (!isWhiteSpace(content.charCodeAt(index))) return false;
+
+    return true;
+  };
+
+  // Find the last meaningful text child - the one end-of-block attributes live on - skipping
+  // trailing whitespace-only text and balanced tag pairs (e.g. an appended permalink); returns -1
+  // when inline code / math or an unmatched opening tag is found first
+  const findEndOfBlockChild = (children: Token[]): number => {
+    const lastIndex = children.length - 1;
+
+    if (lastIndex >= 0) {
+      const lastChild = children[lastIndex];
+
+      // Fast path: no tokens were appended after the attribute text
+      if (lastChild.type === "text" && !isWhitespaceOnly(lastChild.content)) return lastIndex;
+    }
+
+    let depth = 0;
+
+    for (let index = lastIndex; index >= 0; index--) {
+      const child = children[index];
+
+      if (child.type === "code_inline" || child.type === "math_inline") return -1;
+
+      // A closing tag enters a nested structure while scanning backwards
+      if (child.nesting === -1) {
+        depth++;
+        continue;
+      }
+
+      // An opening tag leaves it; bail out on unmatched ones
+      if (child.nesting === 1 && --depth < 0) return -1;
+
+      // Skip nested, non-text and whitespace-only children
+      if (depth > 0 || child.type !== "text" || isWhitespaceOnly(child.content)) continue;
+
+      return index;
+    }
+
+    return -1;
+  };
 
   /** End of {.block} */
   return defineAttrRule({
@@ -15,19 +64,18 @@ export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): At
       {
         shift: 0,
         type: "inline",
-        children: [
-          {
-            position: -1,
-            content: createDelimiterChecker(options, "end"),
-            type: (type) => type !== "code_inline" && type !== "math_inline",
-          },
-        ],
+        children: (children): DelimiterRange | false => {
+          const childIndex = findEndOfBlockChild(children);
+
+          return childIndex === -1 ? false : endDelimiterChecker(children[childIndex].content);
+        },
       },
     ],
-    transform: (tokens, index, childIndex, range): void => {
-      const attrStartIndex = range[0] - options.left.length;
+    transform: (tokens, index, _, range): void => {
       // oxlint-disable-next-line typescript/no-non-null-assertion
-      const token = tokens[index].children![childIndex];
+      const children = tokens[index].children!;
+      const token = children[findEndOfBlockChild(children)];
+      const attrStartIndex = range[0] - options.left.length;
       const { content } = token;
       const hasTrailingSpace = isSpace(content.charCodeAt(attrStartIndex - 1));
 

--- a/packages/plugin-attrs/src/rules/blockEnd.ts
+++ b/packages/plugin-attrs/src/rules/blockEnd.ts
@@ -57,6 +57,10 @@ export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): At
     return -1;
   };
 
+  // Captured by the children test and reused by the transform, which always
+  // runs right after a match, to avoid scanning the children twice
+  let endOfBlockChildIndex = -1;
+
   /** End of {.block} */
   return defineAttrRule({
     name: "end of block",
@@ -65,16 +69,17 @@ export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): At
         shift: 0,
         type: "inline",
         children: (children): DelimiterRange | false => {
-          const childIndex = findEndOfBlockChild(children);
+          endOfBlockChildIndex = findEndOfBlockChild(children);
 
-          return childIndex === -1 ? false : endDelimiterChecker(children[childIndex].content);
+          return endOfBlockChildIndex === -1
+            ? false
+            : endDelimiterChecker(children[endOfBlockChildIndex].content);
         },
       },
     ],
     transform: (tokens, index, _, range): void => {
       // oxlint-disable-next-line typescript/no-non-null-assertion
-      const children = tokens[index].children!;
-      const token = children[findEndOfBlockChild(children)];
+      const token = tokens[index].children![endOfBlockChildIndex];
       const attrStartIndex = range[0] - options.left.length;
       const { content } = token;
       const hasTrailingSpace = isSpace(content.charCodeAt(attrStartIndex - 1));

--- a/packages/plugin-attrs/src/rules/types.ts
+++ b/packages/plugin-attrs/src/rules/types.ts
@@ -29,11 +29,12 @@ export type TokenPropTest = {
  */
 interface BaseAttrRuleSet extends Omit<TokenPropTest, "children"> {
   /**
-   * 子规则集合，用于递归匹配
+   * 子规则集合，用于递归匹配；或一个自定义检查函数，可返回匹配到的分隔符范围
    *
-   * Child rule sets for recursive matching
+   * Child rule sets for recursive matching, or a custom checker function which may return the
+   * matched delimiter range
    */
-  children?: AttrRuleSet[] | TestFunction<Token[]>;
+  children?: AttrRuleSet[] | ((children: Token[]) => DelimiterRange | boolean);
 }
 
 /**


### PR DESCRIPTION
Fix 3 of 4 split from #575 per review (one PR per issue). Rebased on main now that #583 is merged.

### Problem

The end-of-block rule only inspected the last inline child, so a heading-anchor style plugin registered before the attrs rule - appending permalink tokens after the heading text - hid the attributes:

```md
## H2 heading {#my-id}
```

with such a plugin rendered the `{#my-id}` literally (the last child is the appended `link_close`, not the attribute text).

### Fix

Port markdown-it-attrs' `endOfBlockSearch`: scan the inline children backwards for the last meaningful text child, skipping trailing whitespace-only text and balanced tag pairs (e.g. an appended permalink), bailing out on inline code / math and unmatched opening tags:

```html
<h2 id="my-id">H2 heading <a href="#">#</a></h2>
```

The common case - the attribute text is the last child - short-circuits before any scan, and the whitespace check compares char codes via `md.utils.isWhiteSpace` instead of allocating. `AttrRuleSet["children"]` now also accepts a checker function returning the delimiter range to support this. Tests simulate the token-appending plugins in a small shared helper (a real anchor plugin can't be used: it registers after the attrs rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
