### PR TITLE
fix(plugin-attrs): skip delimiters in quoted values

### DIFF
--- a/packages/plugin-attrs/__tests__/helper/getAttrs.spec.ts
+++ b/packages/plugin-attrs/__tests__/helper/getAttrs.spec.ts
@@ -39,6 +39,15 @@ const createDelimiterTests = (
       expect(getAttrs(src, range, options.allowed)).toStrictEqual(expected);
     });
 
+    it(replaceDelimiters("should skip escaped quotes in values", options), () => {
+      const src = replaceDelimiters(String.raw`{a="x\" y"}`, options);
+      const expected = [["a", String.raw`x\" y`]];
+
+      const range = createDelimiterChecker(options, "only")(src) as DelimiterRange;
+
+      expect(getAttrs(src, range, options.allowed)).toStrictEqual(expected);
+    });
+
     it(
       replaceDelimiters(
         String.raw`should parse attributes whose are ignored the key chars(\t,\n,\f,\s,/,>,",',=) eg: {gt>=true slash/=trace i\td "q\fnu e'r\ny"=}`,

--- a/packages/plugin-attrs/__tests__/helper/getDelimiterChecker.spec.ts
+++ b/packages/plugin-attrs/__tests__/helper/getDelimiterChecker.spec.ts
@@ -30,6 +30,30 @@ describe(createDelimiterChecker, () => {
     expect(checker("")).toBe(false);
   });
 
+  it("should ignore delimiters inside quoted values", () => {
+    const startChecker = createDelimiterChecker(options, "start");
+    const endChecker = createDelimiterChecker(options, "end");
+
+    // delimiters inside a quoted value must not start or end the block
+    expect(endChecker('text {.replace-me data-tex="e^{i}=-1"}')).toStrictEqual([6, 37]);
+    expect(startChecker('{a="}"} text')).toStrictEqual([1, 6]);
+
+    // a left delimiter inside an unbalanced quote is not a delimiter
+    expect(endChecker('he said "hi {.c}')).toBe(false);
+
+    // an unterminated block whose only right delimiter is quoted
+    expect(endChecker('x {a="}" y')).toBe(false);
+
+    // escaped quotes do not end a quoted value
+    expect(endChecker(String.raw`text {a="x\" y"}`)).toStrictEqual([6, 15]);
+
+    // a quote at the very start of the content
+    expect(endChecker('"a" {.c}')).toStrictEqual([5, 7]);
+
+    // quotes before the block do not affect end detection
+    expect(endChecker('he said "hi" {.c}')).toStrictEqual([14, 16]);
+  });
+
   it("should check only delimiter", () => {
     const checker = createDelimiterChecker(options, "only");
 

--- a/packages/plugin-attrs/src/helper/constants.ts
+++ b/packages/plugin-attrs/src/helper/constants.ts
@@ -8,3 +8,5 @@ export const PAIR_SEPARATOR = 32;
 export const KEY_SEPARATOR = 61;
 /** " */
 export const QUOTE_MARKER = 34;
+/** \ */
+export const ESCAPE_MARKER = 92;

--- a/packages/plugin-attrs/src/helper/getAttrs.ts
+++ b/packages/plugin-attrs/src/helper/getAttrs.ts
@@ -1,11 +1,6 @@
 import type { DelimiterRange } from "../rules/types.js";
-import {
-  CLASS_MARKER,
-  ID_MARKER,
-  KEY_SEPARATOR,
-  PAIR_SEPARATOR,
-  QUOTE_MARKER,
-} from "./constants.js";
+import { CLASS_MARKER, ID_MARKER, KEY_SEPARATOR, PAIR_SEPARATOR } from "./constants.js";
+import { isUnescapedQuote } from "./getDelimiterChecker.js";
 import type { Attr } from "./types.js";
 
 const isAllowedKeyChar = (charCode: number): boolean =>
@@ -68,12 +63,12 @@ export const getAttrs = (
     }
 
     // {value="inside quotes"}
-    if (charCode === QUOTE_MARKER && value === "" && !valueInsideQuotes) {
+    if (isUnescapedQuote(str, index) && value === "" && !valueInsideQuotes) {
       valueInsideQuotes = true;
       continue;
     }
 
-    if (charCode === QUOTE_MARKER && valueInsideQuotes) {
+    if (isUnescapedQuote(str, index) && valueInsideQuotes) {
       valueInsideQuotes = false;
       continue;
     }

--- a/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
+++ b/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
@@ -1,6 +1,49 @@
 import type { DelimiterChecker } from "../rules/types.js";
-import { CLASS_MARKER, ID_MARKER } from "./constants.js";
+import { CLASS_MARKER, ESCAPE_MARKER, ID_MARKER, QUOTE_MARKER } from "./constants.js";
 import type { DelimiterConfig } from "./types.js";
+
+// Check whether the character at the given index is a double quote that is not escaped
+const isUnescapedQuote = (content: string, index: number): boolean => {
+  if (content.charCodeAt(index) !== QUOTE_MARKER) return false;
+
+  let escapeCount = 0;
+
+  for (let i = index - 1; i >= 0 && content.charCodeAt(i) === ESCAPE_MARKER; i--) escapeCount++;
+
+  return escapeCount % 2 === 0;
+};
+
+// Find the first occurrence of the delimiter outside quoted values, starting at `from`
+const findDelimiter = (content: string, from: number, delimiter: string): number => {
+  // Fast path: without quotes in the searched range there are no quoted values
+  // to skip (the scan below never consults anything before `from` either)
+  if (!content.includes('"', from)) return content.indexOf(delimiter, from);
+
+  let insideQuotes = false;
+
+  for (let index = from; index < content.length; index++) {
+    if (isUnescapedQuote(content, index)) insideQuotes = !insideQuotes;
+    else if (!insideQuotes && content.startsWith(delimiter, index)) return index;
+  }
+
+  return -1;
+};
+
+// Find the last occurrence of the left delimiter outside quoted values
+const findLastLeftDelimiter = (content: string, left: string): number => {
+  // Fast path: without quotes there are no quoted values to skip
+  if (!content.includes('"')) return content.lastIndexOf(left);
+
+  let result = -1;
+  let insideQuotes = false;
+
+  for (let index = 0; index < content.length; index++) {
+    if (isUnescapedQuote(content, index)) insideQuotes = !insideQuotes;
+    else if (!insideQuotes && content.startsWith(left, index)) result = index;
+  }
+
+  return result;
+};
 
 /**
  * Get a function to check if a string matches the delimiter pattern 获取一个函数来检查字符串是否匹配分隔符模式
@@ -35,7 +78,7 @@ export const createDelimiterChecker = (
       if (!content.startsWith(left)) return false;
 
       start = leftLength;
-      end = content.indexOf(right, leftLength + 1);
+      end = findDelimiter(content, leftLength + 1, right);
 
       if (end === -1) return false;
 
@@ -45,11 +88,11 @@ export const createDelimiterChecker = (
       if (nextCharPos < content.length && right.includes(content.charAt(nextCharPos))) return false;
     } else if (where === "end") {
       // Check if content ends with right delimiter
-      start = content.lastIndexOf(left);
+      start = findLastLeftDelimiter(content, left);
 
       if (start === -1) return false;
 
-      end = content.indexOf(right, start + leftLength + 1);
+      end = findDelimiter(content, start + leftLength + 1, right);
       start += leftLength;
 
       if (end === -1 || end + rightLength !== content.length) return false;

--- a/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
+++ b/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
@@ -3,7 +3,7 @@ import { CLASS_MARKER, ESCAPE_MARKER, ID_MARKER, QUOTE_MARKER } from "./constant
 import type { DelimiterConfig } from "./types.js";
 
 // Check whether the character at the given index is a double quote that is not escaped
-const isUnescapedQuote = (content: string, index: number): boolean => {
+export const isUnescapedQuote = (content: string, index: number): boolean => {
   if (content.charCodeAt(index) !== QUOTE_MARKER) return false;
 
   let escapeCount = 0;


### PR DESCRIPTION
Fix 4 of 4 split from #575 per review (one PR per issue).

### Problem

The start/end delimiter checkers used plain `indexOf` / `lastIndexOf`, so a delimiter character inside a quoted attribute value broke detection:

```md
text {.replace-me data-tex="e^{i}=-1"}
```

failed end-detection (the `{` inside the quoted value was taken as the last left delimiter) and rendered literally. Similarly `{a="}"} text` mis-detected the quoted `}` as the end.

### Fix

Scan for delimiters skipping (unescaped) quoted values, like markdown-it-attrs:

```html
<p class="replace-me" data-tex="e^{i}=-1">text</p>
```

Contents without quotes in the searched range keep using the native `indexOf` / `lastIndexOf` fast paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
