### PR TITLE
feat(plugin-attrs): add opt-in dl rule

### DIFF
--- a/docs/src/attrs.md
+++ b/docs/src/attrs.md
@@ -86,7 +86,8 @@ type MarkdownItAttrRuleName =
   // legacy alias of "blockEnd"
   | "block"
   // opt-in, excluded from "all"
-  | "tasklist";
+  | "tasklist"
+  | "dl";
 ```
 
 - Default: `"all"`
@@ -98,7 +99,7 @@ type MarkdownItAttrRuleName =
 
   The `fence` rule only applies to fenced code blocks, while the `blockInfo` rule covers other block tokens carrying attributes on their info line (e.g.: containers from `@mdit/plugin-container`). The `blockEnd` rule applies attributes written at the end of a block element - `block` is its legacy alias.
 
-  The `tasklist` rule supports task list plugins that wrap item contents in a label (e.g. `@mdit/plugin-tasklist`). Task lists are not part of core markdown-it, so this rule must be enabled explicitly in the rule array and is excluded from `"all"`.
+  The `tasklist` rule supports task list plugins that wrap item contents in a label (e.g. `@mdit/plugin-tasklist`). Task lists are not part of core markdown-it, so this rule must be enabled explicitly in the rule array and is excluded from `"all"`. The `dl` rule does the same for definition lists (e.g. `@mdit/plugin-dl`), whose paragraph-wrapped definitions hide attributes from the other rules.
 
 ### allowed
 

--- a/docs/src/zh/attrs.md
+++ b/docs/src/zh/attrs.md
@@ -84,7 +84,8 @@ type MarkdownItAttrRuleName =
   // legacy alias of "blockEnd"
   | "block"
   // opt-in, excluded from "all"
-  | "tasklist";
+  | "tasklist"
+  | "dl";
 ```
 
 - 默认值：`"all"`
@@ -96,7 +97,7 @@ type MarkdownItAttrRuleName =
 
   `fence` 规则仅作用于代码块，而 `blockInfo` 规则作用于其他在信息行上携带属性的块级 token（例如 `@mdit/plugin-container` 的容器）。`blockEnd` 规则作用于写在块级元素末尾的属性，`block` 是它的旧别名。
 
-  `tasklist` 规则为将列表项内容包裹在 label 中的任务列表插件（例如 `@mdit/plugin-tasklist`）提供属性支持。任务列表不属于 markdown-it 核心语法，因此该规则需要在规则数组中显式启用，不包含在 `"all"` 中。
+  `tasklist` 规则为将列表项内容包裹在 label 中的任务列表插件（例如 `@mdit/plugin-tasklist`）提供属性支持。任务列表不属于 markdown-it 核心语法，因此该规则需要在规则数组中显式启用，不包含在 `"all"` 中。`dl` 规则同样为定义列表（例如 `@mdit/plugin-dl`）提供支持，其定义内容被段落包裹，属性对其他规则不可见。
 
 ### allowed
 

--- a/packages/plugin-attrs/__tests__/rules/dl.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/dl.spec.ts
@@ -1,0 +1,106 @@
+import { dl } from "@mdit/plugin-dl";
+import MarkdownIt from "markdown-it";
+import { describe, expect, it } from "vitest";
+
+import { attrs } from "../../src/index.js";
+
+describe("dl rule", () => {
+  const markdownIt = MarkdownIt()
+    .use(attrs, { rule: ["dl"] })
+    .use(dl);
+
+  it("should stay disabled by default", () => {
+    // without the dl rule the generic softbreak rule targets the dd
+    const markdownItDefault = MarkdownIt().use(attrs).use(dl);
+    const expected = `\
+<dl>
+<dt>Term</dt>
+<dd class="fancy">def1</dd>
+<dd>def2</dd>
+</dl>
+`;
+
+    expect(markdownItDefault.render("Term\n: def1\n{.fancy}\n: def2")).toBe(expected);
+  });
+
+  it("should apply attributes to tight definitions", () => {
+    const expected = `\
+<dl>
+<dt>Term</dt>
+<dd class="x">def</dd>
+</dl>
+`;
+
+    expect(markdownIt.render("Term\n: def {.x}")).toBe(expected);
+  });
+
+  it("should support attributes without a leading space", () => {
+    const expected = `\
+<dl>
+<dt>Term</dt>
+<dd class="x">def</dd>
+</dl>
+`;
+
+    expect(markdownIt.render("Term\n: def{.x}")).toBe(expected);
+  });
+
+  it("should apply attributes to loose definitions", () => {
+    const expected = `\
+<dl>
+<dt>Term</dt>
+<dd class="x">
+<p>def</p>
+</dd>
+</dl>
+`;
+
+    expect(markdownIt.render("Term\n\n: def {.x}")).toBe(expected);
+  });
+
+  it("should apply attributes to later definitions", () => {
+    const expected = `\
+<dl>
+<dt>Term</dt>
+<dd>def1</dd>
+<dd id="did">def2</dd>
+</dl>
+`;
+
+    expect(markdownIt.render("Term\n: def1\n: def2 {#did}")).toBe(expected);
+  });
+
+  it("should apply attributes after a softbreak to the definition list", () => {
+    const expected = `\
+<dl class="fancy">
+<dt>Term</dt>
+<dd>def</dd>
+</dl>
+`;
+
+    expect(markdownIt.render("Term\n: def\n{.fancy}")).toBe(expected);
+  });
+
+  it("should apply softbreak attributes from a middle definition", () => {
+    const expected = `\
+<dl class="fancy">
+<dt>Term</dt>
+<dd>def1</dd>
+<dd>def2</dd>
+</dl>
+`;
+
+    expect(markdownIt.render("Term\n: def1\n{.fancy}\n: def2")).toBe(expected);
+  });
+
+  it("should apply attributes in a paragraph after the definition list", () => {
+    const expected = `\
+<dl class="b">
+<dt>Term</dt>
+<dd>def</dd>
+</dl>
+`;
+
+    expect(markdownIt.render("Term\n: def\n\n{.b}")).toBe(expected);
+  });
+});

--- a/packages/plugin-attrs/package.json
+++ b/packages/plugin-attrs/package.json
@@ -49,6 +49,7 @@
   },
   "devDependencies": {
     "@mdit/plugin-container": "workspace:*",
+    "@mdit/plugin-dl": "workspace:*",
     "@mdit/plugin-figure": "workspace:*",
     "@mdit/plugin-katex": "workspace:*",
     "@mdit/plugin-mark": "workspace:*",

--- a/packages/plugin-attrs/src/options.ts
+++ b/packages/plugin-attrs/src/options.ts
@@ -13,7 +13,9 @@ export type MarkdownItAttrRuleName =
   /** Legacy alias of `blockEnd` */
   | "block"
   /** Opt-in task list label support - excluded from `"all"` */
-  | "tasklist";
+  | "tasklist"
+  /** Opt-in definition list support - excluded from `"all"` */
+  | "dl";
 
 export interface MarkdownItAttrsOptions extends Partial<DelimiterConfig> {
   /**

--- a/packages/plugin-attrs/src/rules/dl.ts
+++ b/packages/plugin-attrs/src/rules/dl.ts
@@ -44,7 +44,8 @@ export const createDlRules = (md: MarkdownIt, options: DelimiterConfig): AttrRul
 
         let dlOpenIndex = index - 2;
 
-        // Find the definition list opening token
+        // Find the definition list opening token - a dd always has an
+        // enclosing dl, so the scan cannot run past the start of the stream
         while (tokens[dlOpenIndex - 1].type !== "dl_open") dlOpenIndex--;
 
         // Apply attributes to the definition list opening token

--- a/packages/plugin-attrs/src/rules/dl.ts
+++ b/packages/plugin-attrs/src/rules/dl.ts
@@ -1,0 +1,130 @@
+import type MarkdownIt from "markdown-it";
+
+import type { DelimiterConfig } from "../helper/index.js";
+import { addAttrs, createDelimiterChecker, getMatchingOpeningToken } from "../helper/index.js";
+import type { AttrRule } from "./types.js";
+import { defineAttrRule } from "./types.js";
+
+// List rules for definition lists (@mdit/plugin-dl): dd contents are wrapped
+// in (possibly hidden) paragraphs and no list_item_open exists, so neither the
+// standard list rules nor the end-of-block rule can target the dd or dl
+export const createDlRules = (md: MarkdownIt, options: DelimiterConfig): AttrRule[] => {
+  const isSpace = md.utils.isSpace;
+  const allowed = options.allowed;
+
+  return [
+    /** : Definition \n {.a} */
+    defineAttrRule({
+      name: "dl softbreak",
+      tests: [
+        {
+          shift: -2,
+          type: "dd_open",
+        },
+        {
+          shift: 0,
+          type: "inline",
+          children: [
+            {
+              position: -2,
+              type: "softbreak",
+            },
+            {
+              position: -1,
+              type: "text",
+              content: createDelimiterChecker(options, "only"),
+            },
+          ],
+        },
+      ],
+      transform: (tokens, index, childIndex, range): void => {
+        // oxlint-disable-next-line typescript/no-non-null-assertion
+        const childTokens = tokens[index].children!;
+        const token = childTokens[childIndex];
+
+        let dlOpenIndex = index - 2;
+
+        // Find the definition list opening token
+        while (tokens[dlOpenIndex - 1].type !== "dl_open") dlOpenIndex--;
+
+        // Apply attributes to the definition list opening token
+        addAttrs(tokens[dlOpenIndex - 1], token.content, range, allowed);
+
+        // Remove the attribute tokens from children
+        tokens[index].children = childTokens.slice(0, -2);
+      },
+    }),
+
+    /** {.a} in its own paragraph after a definition list */
+    defineAttrRule({
+      name: "dl double softbreak",
+      tests: [
+        {
+          shift: 0,
+          type: "dl_close",
+        },
+        {
+          shift: 1,
+          type: "paragraph_open",
+        },
+        {
+          shift: 2,
+          type: "inline",
+          content: createDelimiterChecker(options, "only"),
+          children: (children) => children.length === 1,
+        },
+        {
+          shift: 3,
+          type: "paragraph_close",
+        },
+      ],
+      transform: (tokens, index, _, range): void => {
+        const token = tokens[index + 2];
+        const openingToken = getMatchingOpeningToken(tokens, index);
+
+        // Apply attributes to the definition list opening token
+        addAttrs(openingToken, token.content, range, allowed);
+
+        // Remove the paragraph tokens containing the attributes
+        tokens.splice(index + 1, 3);
+      },
+    }),
+
+    /** : End of {.definition} */
+    defineAttrRule({
+      name: "dl item end",
+      tests: [
+        {
+          // the dd's first paragraph: dd_open sits behind the paragraph_open
+          shift: -2,
+          type: "dd_open",
+        },
+        {
+          shift: 0,
+          type: "inline",
+          children: [
+            {
+              position: -1,
+              type: "text",
+              content: createDelimiterChecker(options, "end"),
+            },
+          ],
+        },
+      ],
+      transform: (tokens, index, childIndex, range): void => {
+        // oxlint-disable-next-line typescript/no-non-null-assertion
+        const token = tokens[index].children![childIndex];
+        const content = token.content;
+        const attrStartIndex = range[0] - options.left.length;
+        const hasTrailingSpace = isSpace(content.charCodeAt(attrStartIndex - 1));
+
+        // Apply attributes to the dd opening token - the end-of-block rule
+        // cannot: its target is the paragraph, which is hidden in tight lists
+        addAttrs(tokens[index - 2], content, range, allowed);
+
+        // Remove attribute syntax from content
+        token.content = content.slice(0, hasTrailingSpace ? attrStartIndex - 1 : attrStartIndex);
+      },
+    }),
+  ];
+};

--- a/packages/plugin-attrs/src/rules/rules.ts
+++ b/packages/plugin-attrs/src/rules/rules.ts
@@ -3,6 +3,7 @@ import type MarkdownIt from "markdown-it";
 import type { MarkdownItAttrRuleName, MarkdownItAttrsOptions } from "../options.js";
 import { createBlockEndRule } from "./blockEnd.js";
 import { createBlockInfoRule } from "./blockInfo.js";
+import { createDlRules } from "./dl.js";
 import { createFenceRule } from "./fence.js";
 import { createHeadingRule } from "./heading.js";
 import { createHrRule } from "./hr.js";
@@ -27,7 +28,7 @@ const AVAILABLE_RULES: MarkdownItAttrRuleName[] = [
 ];
 
 // Opt-in rules for third-party plugin interop - excluded from "all"
-const EXTENSION_RULES = new Set<MarkdownItAttrRuleName>(["tasklist"]);
+const EXTENSION_RULES = new Set<MarkdownItAttrRuleName>(["dl", "tasklist"]);
 
 export const createRules = (
   md: MarkdownIt,
@@ -49,6 +50,7 @@ export const createRules = (
   if (enabledRules.includes("table")) rules.push(...createTableRules(md, options));
   if (enabledRules.includes("list")) rules.push(...createListRules(md, options));
   if (enabledRules.includes("tasklist")) rules.push(...createTasklistRules(md, options));
+  if (enabledRules.includes("dl")) rules.push(...createDlRules(md, options));
   if (enabledRules.includes("softbreak")) rules.push(createSoftBreakRule(options));
   if (enabledRules.includes("hr")) rules.push(createHrRule(md, options));
   if (enabledRules.includes("blockInfo")) rules.push(createBlockInfoRule(md, options));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
       '@mdit/plugin-container':
         specifier: workspace:*
         version: link:../plugin-container
+      '@mdit/plugin-dl':
+        specifier: workspace:*
+        version: link:../plugin-dl
       '@mdit/plugin-figure':
         specifier: workspace:*
         version: link:../plugin-figure


### PR DESCRIPTION
Follow-up to the review discussion on #575 ("we could add support for things like plugin-dl as well"). Builds on the extension-rule mechanism from #580.

### Problem

`@mdit/plugin-dl` wraps definition contents in (possibly hidden) paragraphs and emits no `list_item_open`, so no existing rule can target the `dd` or `dl`:

```md
Term
: definition {.x}
```

applies the class to the *hidden* paragraph inside the tight `dd` — it renders nothing, so the attribute is silently lost (the `{.x}` text is still stripped). Own-line attributes are inconsistent: `{.y}` after a softbreak reaches the `<dl>` only from the last definition and lands on the `<dd>` from any other; a `{.b}` paragraph after the list matches nothing and renders as a stray `<p>`.

### Fix

An opt-in `dl` rule (excluded from `"all"`, like `tasklist`) with dd/dl-aware variants of the three list rules:

- `dl item end` — `: definition {.x}` → `<dd class="x">` (targets the `dd_open` behind the paragraph, so tight and loose definitions both work)
- `dl softbreak` — own-line `{.y}` → `<dl class="y">` consistently from any definition
- `dl double softbreak` — `{.b}` paragraph after the list → `<dl class="b">`, paragraph removed

`dt`-end attributes (`Term {.x}`) need no new rule — the `dt` inline is directly followed by `dt_close`, which the end-of-block rule handles (correctly targeting the `dt` once #583 lands).

Tests use the real `@mdit/plugin-dl` (new devDependency) including a default-config test proving the rule stays off. Coverage stays 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
