### PR TITLE
perf(plugin-attrs): reduce quote scan overhead

### DIFF
--- a/packages/plugin-attrs/__tests__/helper/getDelimiterChecker.spec.ts
+++ b/packages/plugin-attrs/__tests__/helper/getDelimiterChecker.spec.ts
@@ -52,6 +52,9 @@ describe(createDelimiterChecker, () => {
 
     // quotes before the block do not affect end detection
     expect(endChecker('he said "hi" {.c}')).toStrictEqual([14, 16]);
+
+    // quotes after the block do not trigger the quote scan
+    expect(startChecker('{.c} "q"')).toStrictEqual([1, 3]);
   });
 
   it("should check only delimiter", () => {

--- a/packages/plugin-attrs/src/helper/getAttrs.ts
+++ b/packages/plugin-attrs/src/helper/getAttrs.ts
@@ -1,5 +1,11 @@
 import type { DelimiterRange } from "../rules/types.js";
-import { CLASS_MARKER, ID_MARKER, KEY_SEPARATOR, PAIR_SEPARATOR } from "./constants.js";
+import {
+  CLASS_MARKER,
+  ID_MARKER,
+  KEY_SEPARATOR,
+  PAIR_SEPARATOR,
+  QUOTE_MARKER,
+} from "./constants.js";
 import { isUnescapedQuote } from "./getDelimiterChecker.js";
 import type { Attr } from "./types.js";
 
@@ -63,12 +69,17 @@ export const getAttrs = (
     }
 
     // {value="inside quotes"}
-    if (isUnescapedQuote(str, index) && value === "" && !valueInsideQuotes) {
+    if (
+      charCode === QUOTE_MARKER &&
+      isUnescapedQuote(str, index) &&
+      value === "" &&
+      !valueInsideQuotes
+    ) {
       valueInsideQuotes = true;
       continue;
     }
 
-    if (isUnescapedQuote(str, index) && valueInsideQuotes) {
+    if (charCode === QUOTE_MARKER && isUnescapedQuote(str, index) && valueInsideQuotes) {
       valueInsideQuotes = false;
       continue;
     }

--- a/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
+++ b/packages/plugin-attrs/src/helper/getDelimiterChecker.ts
@@ -15,9 +15,14 @@ export const isUnescapedQuote = (content: string, index: number): boolean => {
 
 // Find the first occurrence of the delimiter outside quoted values, starting at `from`
 const findDelimiter = (content: string, from: number, delimiter: string): number => {
-  // Fast path: without quotes in the searched range there are no quoted values
-  // to skip (the scan below never consults anything before `from` either)
-  if (!content.includes('"', from)) return content.indexOf(delimiter, from);
+  const delimiterIndex = content.indexOf(delimiter, from);
+
+  if (delimiterIndex === -1) return -1;
+
+  // Fast path: without a quote before the delimiter it cannot be inside a quoted value
+  const quoteIndex = content.indexOf('"', from);
+
+  if (quoteIndex === -1 || quoteIndex > delimiterIndex) return delimiterIndex;
 
   let insideQuotes = false;
 
@@ -31,8 +36,14 @@ const findDelimiter = (content: string, from: number, delimiter: string): number
 
 // Find the last occurrence of the left delimiter outside quoted values
 const findLastLeftDelimiter = (content: string, left: string): number => {
-  // Fast path: without quotes there are no quoted values to skip
-  if (!content.includes('"')) return content.lastIndexOf(left);
+  const leftIndex = content.lastIndexOf(left);
+
+  if (leftIndex === -1) return -1;
+
+  // Fast path: without a quote before the delimiter it cannot be inside a quoted value
+  const quoteIndex = content.indexOf('"');
+
+  if (quoteIndex === -1 || quoteIndex > leftIndex) return leftIndex;
 
   let result = -1;
   let insideQuotes = false;


### PR DESCRIPTION
Follow-up to the post-merge review comments on #585 ([1](https://github.com/mdit-plugins/mdit-plugins/pull/585#discussion_r3655771169), [2](https://github.com/mdit-plugins/mdit-plugins/pull/585#discussion_r3655771215)):

- `findDelimiter` / `findLastLeftDelimiter` now locate the delimiter first and fall back to the quote-aware scan only when a quote appears *before* it — a single pass in the common quote-free case, an early exit when the delimiter is absent, and no behavior change (the added spec case covers the quote-after-delimiter path).
- The `getAttrs` quote toggles guard the `isUnescapedQuote` calls with the already-available `charCode`, restoring the cheap per-character hot path from before #585.

Coverage stays 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
