### PR TITLE
docs(plugin-attrs): clarify two internal comments

### DIFF
--- a/packages/plugin-attrs/src/rules/blockEnd.ts
+++ b/packages/plugin-attrs/src/rules/blockEnd.ts
@@ -11,7 +11,7 @@ export const createBlockEndRule = (md: MarkdownIt, options: DelimiterConfig): At
   const isWhiteSpace = md.utils.isWhiteSpace;
   const endDelimiterChecker = createDelimiterChecker(options, "end");
 
-  // Non-allocating `content.trim() === ""`
+  // Non-allocating whitespace-only check (markdown-it's whitespace set)
   const isWhitespaceOnly = (content: string): boolean => {
     for (let index = 0; index < content.length; index++)
       if (!isWhiteSpace(content.charCodeAt(index))) return false;

--- a/packages/plugin-attrs/src/rules/types.ts
+++ b/packages/plugin-attrs/src/rules/types.ts
@@ -29,10 +29,11 @@ export type TokenPropTest = {
  */
 interface BaseAttrRuleSet extends Omit<TokenPropTest, "children"> {
   /**
-   * 子规则集合，用于递归匹配；或一个自定义检查函数，可返回匹配到的分隔符范围
+   * 子规则集合，用于递归匹配；或一个自定义检查函数，可返回匹配到的分隔符范围。当该函数返回布尔值时，分隔符范围需由规则的其他测试提供
    *
    * Child rule sets for recursive matching, or a custom checker function which may return the
-   * matched delimiter range
+   * matched delimiter range. When the function returns a boolean instead, another test of the rule
+   * must provide the delimiter range
    */
   children?: AttrRuleSet[] | ((children: Token[]) => DelimiterRange | boolean);
 }


### PR DESCRIPTION
Follow-up to the post-merge review comments on #584 ([1](https://github.com/mdit-plugins/mdit-plugins/pull/584#discussion_r3655860015), [2](https://github.com/mdit-plugins/mdit-plugins/pull/584#discussion_r3655860052)):

- The `children` jsdoc now states the contract explicitly: a checker returning a boolean relies on another test of the rule to provide the delimiter range. That boolean form predates #584 (the `list double softbreak` rule uses `children.length === 1` with its range coming from the sibling `content` checker), so splitting the type would break a legitimately used shape of this internal interface — documenting the contract instead.
- The `isWhitespaceOnly` comment no longer implies `trim()` semantics; it follows `md.utils.isWhiteSpace`.

Comment-only, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
