### PR TITLE
chore: rename pluginPackages in verifyCommit

### DIFF
--- a/scripts/verifyCommit.ts
+++ b/scripts/verifyCommit.ts
@@ -12,7 +12,7 @@ const getSubDirectories = async (dir: string): Promise<string[]> => {
   return items.filter((_, index) => stats[index].isDirectory());
 };
 
-const pluginPackages = await getSubDirectories(path.join(__dirname, "../packages"));
+const packageDirectories = await getSubDirectories(path.join(__dirname, "../packages"));
 
 const msgPath = process.argv[2]
   ? path.resolve(process.argv[2])
@@ -34,7 +34,7 @@ const types = [
   "types",
   "release",
 ];
-const scopes = [...pluginPackages, "deps"];
+const scopes = [...packageDirectories, "deps"];
 
 const commitRE = /^(?:revert: )?(?<type>[^(]*?)(?:\((?<scope>[^)]*?)\))?!?: .{1,50}$/mu;
 


### PR DESCRIPTION
Follow-up to the [post-merge review comment on #573](https://github.com/mdit-plugins/mdit-plugins/pull/573#discussion_r3650181729): `pluginPackages` holds every `packages/` subdirectory - including non-plugin ones like `helper` - so rename it to `packageDirectories`. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
