### PR TITLE
feat(plugin-attrs): export rule lists and types

### DIFF
--- a/docs/src/attrs.md
+++ b/docs/src/attrs.md
@@ -101,6 +101,12 @@ type MarkdownItAttrRuleName =
 
   The `tasklist` rule supports task list plugins that wrap item contents in a label (e.g. `@mdit/plugin-tasklist`). Task lists are not part of core markdown-it, so this rule must be enabled explicitly in the rule array and is excluded from `"all"`. The `dl` rule does the same for definition lists (e.g. `@mdit/plugin-dl`), whose paragraph-wrapped definitions hide attributes from the other rules.
 
+  The package exports the rule name lists as `DEFAULT_RULES` (the `"all"` set) and `EXTENSION_RULES`, so you can tweak the defaults without hardcoding them:
+
+  ```ts
+  mdIt.use(attrs, { rule: DEFAULT_RULES.filter((name) => name !== "fence") });
+  ```
+
 ### allowed
 
 - Type: `(string | RegExp)[]`

--- a/docs/src/zh/attrs.md
+++ b/docs/src/zh/attrs.md
@@ -99,6 +99,12 @@ type MarkdownItAttrRuleName =
 
   `tasklist` 规则为将列表项内容包裹在 label 中的任务列表插件（例如 `@mdit/plugin-tasklist`）提供属性支持。任务列表不属于 markdown-it 核心语法，因此该规则需要在规则数组中显式启用，不包含在 `"all"` 中。`dl` 规则同样为定义列表（例如 `@mdit/plugin-dl`）提供支持，其定义内容被段落包裹，属性对其他规则不可见。
 
+  包导出了规则名称列表 `DEFAULT_RULES`（`"all"` 对应的集合）和 `EXTENSION_RULES`，无需硬编码即可调整默认规则：
+
+  ```ts
+  mdIt.use(attrs, { rule: DEFAULT_RULES.filter((name) => name !== "fence") });
+  ```
+
 ### allowed
 
 - 类型：`(string | RegExp)[]`

--- a/packages/plugin-attrs/__tests__/options.spec.ts
+++ b/packages/plugin-attrs/__tests__/options.spec.ts
@@ -1,7 +1,8 @@
+import { tasklist } from "@mdit/plugin-tasklist";
 import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
-import { attrs } from "../src/index.js";
+import { attrs, DEFAULT_RULES, EXTENSION_RULES } from "../src/index.js";
 
 describe("rule settings", () => {
   it("should disable all rules when rule option is false", () => {
@@ -62,5 +63,39 @@ describe("rule settings", () => {
     expect(markdownIt.render("text {.some-class #some-id attr=allowed}")).toBe(
       '<p class="some-class" attr="allowed">text</p>\n',
     );
+  });
+});
+
+describe("exported rule lists", () => {
+  it("should match the all preset", () => {
+    const markdownItAll = MarkdownIt().use(attrs);
+    const markdownItList = MarkdownIt().use(attrs, { rule: DEFAULT_RULES });
+    const src = "# heading {#id}\n\ntext {.c}\n\n```js {.fence}\nconst a = 1;\n```\n";
+
+    expect(markdownItList.render(src)).toBe(markdownItAll.render(src));
+  });
+
+  it("should support filtering out a single rule", () => {
+    const markdownIt = MarkdownIt().use(attrs, {
+      rule: DEFAULT_RULES.filter((name) => name !== "fence"),
+    });
+
+    expect(markdownIt.render("```js {.fence}\nconst a = 1;\n```\n")).toBe(
+      '<pre><code class="language-js">const a = 1;\n</code></pre>\n',
+    );
+    expect(markdownIt.render("text {.c}")).toBe('<p class="c">text</p>\n');
+  });
+
+  it("should enable extension rules together with the defaults", () => {
+    const markdownIt = MarkdownIt()
+      .use(attrs, { rule: [...DEFAULT_RULES, ...EXTENSION_RULES] })
+      .use(tasklist);
+    const expected = `\
+<ul class="task-list-container">
+<li class="task-list-item red"><input type="checkbox" class="task-list-item-checkbox" id="task-item-0" disabled="disabled"><label class="task-list-item-label" for="task-item-0"> foo</label></li>
+</ul>
+`;
+
+    expect(markdownIt.render("- [ ] foo {.red}")).toBe(expected);
   });
 });

--- a/packages/plugin-attrs/src/index.ts
+++ b/packages/plugin-attrs/src/index.ts
@@ -1,2 +1,3 @@
 export type * from "./options.js";
 export * from "./plugin.js";
+export { DEFAULT_RULES, EXTENSION_RULES } from "./rules/rules.js";

--- a/packages/plugin-attrs/src/options.ts
+++ b/packages/plugin-attrs/src/options.ts
@@ -1,6 +1,11 @@
 import type { DelimiterConfig } from "./helper/index.js";
 
-export type MarkdownItAttrRuleName =
+/**
+ * Rules enabled by default (`"all"`)
+ *
+ * 默认启用的规则（`"all"`）
+ */
+export type MarkdownItAttrsDefaultRuleName =
   | "fence"
   | "inline"
   | "table"
@@ -9,13 +14,20 @@ export type MarkdownItAttrRuleName =
   | "hr"
   | "softbreak"
   | "blockInfo"
-  | "blockEnd"
+  | "blockEnd";
+
+/**
+ * Opt-in rules for third-party plugin interop - excluded from `"all"`
+ *
+ * 需显式启用的第三方插件交互规则，不包含在 `"all"` 中
+ */
+export type MarkdownItAttrsExtensionRuleName = "tasklist" | "dl";
+
+export type MarkdownItAttrRuleName =
+  | MarkdownItAttrsDefaultRuleName
+  | MarkdownItAttrsExtensionRuleName
   /** Legacy alias of `blockEnd` */
-  | "block"
-  /** Opt-in task list label support - excluded from `"all"` */
-  | "tasklist"
-  /** Opt-in definition list support - excluded from `"all"` */
-  | "dl";
+  | "block";
 
 export interface MarkdownItAttrsOptions extends Partial<DelimiterConfig> {
   /**
@@ -25,5 +37,5 @@ export interface MarkdownItAttrsOptions extends Partial<DelimiterConfig> {
    *
    * @default "all"
    */
-  rule?: "all" | boolean | MarkdownItAttrRuleName[];
+  rule?: "all" | boolean | readonly MarkdownItAttrRuleName[];
 }

--- a/packages/plugin-attrs/src/rules/rules.ts
+++ b/packages/plugin-attrs/src/rules/rules.ts
@@ -1,6 +1,11 @@
 import type MarkdownIt from "markdown-it";
 
-import type { MarkdownItAttrRuleName, MarkdownItAttrsOptions } from "../options.js";
+import type {
+  MarkdownItAttrRuleName,
+  MarkdownItAttrsDefaultRuleName,
+  MarkdownItAttrsExtensionRuleName,
+  MarkdownItAttrsOptions,
+} from "../options.js";
 import { createBlockEndRule } from "./blockEnd.js";
 import { createBlockInfoRule } from "./blockInfo.js";
 import { createDlRules } from "./dl.js";
@@ -14,7 +19,12 @@ import { createTableRules } from "./table.js";
 import { createTasklistRules } from "./tasklist.js";
 import type { AttrRule } from "./types.js";
 
-const AVAILABLE_RULES: MarkdownItAttrRuleName[] = [
+/**
+ * Rule names enabled by `"all"`
+ *
+ * `"all"` 启用的规则名称
+ */
+export const DEFAULT_RULES: readonly MarkdownItAttrsDefaultRuleName[] = [
   "fence",
   "inline",
   "table",
@@ -24,24 +34,33 @@ const AVAILABLE_RULES: MarkdownItAttrRuleName[] = [
   "softbreak",
   "blockInfo",
   "blockEnd",
-  "block",
 ];
 
-// Opt-in rules for third-party plugin interop - excluded from "all"
-const EXTENSION_RULES = new Set<MarkdownItAttrRuleName>(["dl", "tasklist"]);
+/**
+ * Opt-in rules for third-party plugin interop - excluded from `"all"`
+ *
+ * 需显式启用的第三方插件交互规则，不包含在 `"all"` 中
+ */
+export const EXTENSION_RULES: readonly MarkdownItAttrsExtensionRuleName[] = ["tasklist", "dl"];
+
+const SUPPORTED_RULES = new Set<MarkdownItAttrRuleName>([
+  ...DEFAULT_RULES,
+  ...EXTENSION_RULES,
+  "block",
+]);
 
 export const createRules = (
   md: MarkdownIt,
   options: Required<MarkdownItAttrsOptions>,
 ): AttrRule[] => {
-  const enabledRules =
+  const enabledRules: readonly MarkdownItAttrRuleName[] =
     // disable
     options.rule === false
       ? []
       : Array.isArray(options.rule)
         ? // user specific rules
-          options.rule.filter((item) => AVAILABLE_RULES.includes(item) || EXTENSION_RULES.has(item))
-        : AVAILABLE_RULES;
+          options.rule.filter((item: MarkdownItAttrRuleName) => SUPPORTED_RULES.has(item))
+        : DEFAULT_RULES;
 
   const rules: AttrRule[] = [];
 


### PR DESCRIPTION
Exports the rule name lists and structures the rule name types, so consumers can tweak the default rule set without hardcoding it — e.g. VitePress wants everything except `fence` (its highlighter handles fence attributes) and today that means copying all nine names and silently missing any rule added later:

```ts
mdIt.use(attrs, { rule: DEFAULT_RULES.filter((name) => name !== "fence") });
```

### Shape (open to discussion)

- `DEFAULT_RULES: readonly MarkdownItAttrsDefaultRuleName[]` — the `"all"` set
- `EXTENSION_RULES: readonly MarkdownItAttrsExtensionRuleName[]` — the opt-in interop rules (`tasklist`, `dl`)
- `MarkdownItAttrRuleName` is unchanged in shape but now composed of the two exported sub-unions plus the documented legacy `"block"` alias (kept out of both lists)
- the `rule` option accepts `readonly` arrays, so the constants and their `.filter()` results pass directly
- internally `createRules` consumes the exported lists, so they cannot drift from the actual behavior

Happy to adjust naming or granularity — e.g. an `exclude` form on the `rule` option instead, if you'd rather not expose the lists.

Rebased on main now that #586 is merged. Coverage stays 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
