### PR TITLE
refactor(plugin-attrs): drop a stray optional chain

### DIFF
--- a/packages/plugin-attrs/src/rules/list.ts
+++ b/packages/plugin-attrs/src/rules/list.ts
@@ -41,9 +41,10 @@ export const createListRules = (md: MarkdownIt, options: DelimiterConfig): AttrR
 
         let listOpenIndex = index - 2;
 
-        // Find the list opening token
+        // Find the list opening token - a list item always has an enclosing
+        // list, so the scan cannot run past the start of the stream
         while (
-          tokens[listOpenIndex - 1]?.type !== "ordered_list_open" &&
+          tokens[listOpenIndex - 1].type !== "ordered_list_open" &&
           tokens[listOpenIndex - 1].type !== "bullet_list_open"
         )
           listOpenIndex--;

--- a/packages/plugin-attrs/src/rules/tasklist.ts
+++ b/packages/plugin-attrs/src/rules/tasklist.ts
@@ -49,7 +49,8 @@ export const createTasklistRules = (md: MarkdownIt, options: DelimiterConfig): A
 
         let listOpenIndex = index - 2;
 
-        // Find the list opening token
+        // Find the list opening token - a list item always has an enclosing
+        // list, so the scan cannot run past the start of the stream
         while (
           tokens[listOpenIndex - 1].type !== "ordered_list_open" &&
           tokens[listOpenIndex - 1].type !== "bullet_list_open"


### PR DESCRIPTION
Automated review keeps flagging the list-opening walk as an underflow risk (three times across recent PRs), triggered by the asymmetric guard in `list.ts`: the first condition uses optional chaining, the second does not. The walk cannot underflow — the rules require a `list_item_open` two tokens back, and markdown-it never emits one without its enclosing list opening earlier in the stream. (Guarding both conditions would instead loop forever on the impossible stream.)

Use plain access in both conditions and document the invariant on the `list.ts` and `tasklist.ts` walks, matching the pending `dl` rule in #586. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
