### PR TITLE
fix(plugin-figure): omit empty figcaption for captionless images

### DIFF
--- a/packages/plugin-figure/__tests__/figure.spec.ts
+++ b/packages/plugin-figure/__tests__/figure.spec.ts
@@ -61,9 +61,13 @@ test ![image](/logo.svg)
     );
   });
 
-  it("should handle empty caption", () => {
+  it("should not add figcaption when caption is empty", () => {
     expect(markdownIt.render("![](/logo.svg)")).toBe(
-      '<figure><img src="/logo.svg" alt="" tabindex="0"><figcaption></figcaption></figure>\n',
+      '<figure><img src="/logo.svg" alt="" tabindex="0"></figure>\n',
+    );
+
+    expect(markdownIt.render("[![](/logo.svg)](https://example.com)")).toBe(
+      '<figure><a href="https://example.com"><img src="/logo.svg" alt="" tabindex="0"></a></figure>\n',
     );
   });
 

--- a/packages/plugin-figure/src/plugin.ts
+++ b/packages/plugin-figure/src/plugin.ts
@@ -73,15 +73,16 @@ export const figure: PluginWithOptions<MarkdownItFigureOptions> = (md, options =
 
       const figCaption = getCaption(image);
 
-      token.children.push(new state.Token("figcaption_open", "figcaption", 1));
+      if (figCaption) {
+        const [captionContent] = md.parseInline(figCaption, state.env);
 
-      const [captionContent] = md.parseInline(figCaption, state.env);
-      const children = captionContent.children;
-
-      // oxlint-disable-next-line typescript/strict-boolean-expressions
-      if (children?.length) token.children.push(...children);
-
-      token.children.push(new state.Token("figcaption_close", "figcaption", -1));
+        token.children.push(
+          new state.Token("figcaption_open", "figcaption", 1),
+          // oxlint-disable-next-line typescript/no-non-null-assertion
+          ...captionContent.children!,
+          new state.Token("figcaption_close", "figcaption", -1),
+        );
+      }
 
       if (options.focusable !== false) image.attrPush(["tabindex", "0"]);
     }


### PR DESCRIPTION
### Rationale

`@mdit/plugin-figure`'s ancestor markdown-it-image-figures@2.1.1 never emits a `<figcaption>` element when the caption text is empty (it checks `if (figCaption)` before pushing the tokens). Our port always pushes `figcaption_open`/`figcaption_close`, so `![](fig.png)` — empty alt, no title, an extremely common pattern for decorative images and screenshots — renders a useless empty `<figcaption></figcaption>` that themes typically style with margins/typography. Users migrating from the upstream plugin get this on every captionless image.

### Repro

```js
import MarkdownIt from "markdown-it";
import { figure } from "@mdit/plugin-figure";

const md = MarkdownIt().use(figure);
```

Input:

```md
![](fig.png)
```

Current output:

```html
<figure><img src="fig.png" alt="" tabindex="0"><figcaption></figcaption></figure>
```

markdown-it@14.3.0 + markdown-it-image-figures@2.1.1 output:

```html
<figure><img src="fig.png" alt=""></figure>
```

Fixed output:

```html
<figure><img src="fig.png" alt="" tabindex="0"></figure>
```

Same for linked images: `[![](fig.png)](link.html)` currently gets `<figcaption></figcaption>` appended after the `</a>`, while upstream renders `<figure><a href="link.html"><img src="fig.png" alt=""></a></figure>`.

### Root cause

`packages/plugin-figure/src/plugin.ts`: the figcaption tokens are pushed unconditionally; only the parsed caption children are guarded by `children?.length`.

### Fix

Guard the whole caption handling with `if (figCaption)` (as upstream does), so `md.parseInline` is skipped and no caption element is emitted when there is nothing to put in it — a non-empty caption source always parses to at least one inline child. The existing "should handle empty caption" test pinned the old behavior — updated to expect the upstream-parity output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
