### PR TITLE
fix(plugin-anchor): allow ariaHidden preset to disable aria-hidden

### DIFF
--- a/packages/plugin-anchor/__tests__/permalink-ariaHidden.spec.ts
+++ b/packages/plugin-anchor/__tests__/permalink-ariaHidden.spec.ts
@@ -14,6 +14,12 @@ describe("permalink.ariaHidden", () => {
     );
   });
 
+  it("should allow disabling aria-hidden", () => {
+    expect(md({ permalink: ariaHidden({ ariaHidden: false }) }).render("# H1")).toBe(
+      '<h1 id="h1" tabindex="-1">H1 <a class="header-anchor" href="#h1">#</a></h1>\n',
+    );
+  });
+
   it("should render with HTML symbol", () => {
     expect(md({ permalink: ariaHidden({ symbol: '<i class="icon"></i>' }) }).render("# H1")).toBe(
       '<h1 id="h1" tabindex="-1">H1 <a class="header-anchor" href="#h1" aria-hidden="true"><i class="icon"></i></a></h1>\n',

--- a/packages/plugin-anchor/src/permalink/ariaHidden.ts
+++ b/packages/plugin-anchor/src/permalink/ariaHidden.ts
@@ -2,4 +2,4 @@ import { linkInsideHeader } from "./linkInsideHeader.js";
 import type { LinkInsideHeaderPermalinkOptions, PermalinkGenerator } from "./types.js";
 
 export const ariaHidden = (opts?: LinkInsideHeaderPermalinkOptions): PermalinkGenerator =>
-  linkInsideHeader({ ...opts, ariaHidden: true });
+  linkInsideHeader({ ariaHidden: true, ...opts });


### PR DESCRIPTION
### Rationale

In markdown-it-anchor@9.2.1, the `ariaHidden` permalink preset treats `ariaHidden: true` as a mere default that user options can override. In `@mdit/plugin-anchor` the preset force-overwrites a user-passed `ariaHidden: false`, even though `LinkInsideHeaderPermalinkOptions` (the preset's declared options type) advertises the option. A migrating user who passes `ariaHidden({ ariaHidden: false })` silently keeps `aria-hidden="true"`.

### Repro

```js
import MarkdownIt from "markdown-it";
import { anchor, ariaHidden } from "@mdit/plugin-anchor";

const md = MarkdownIt({ html: true }).use(anchor, {
  permalink: ariaHidden({ ariaHidden: false }),
});
```

Input:

```markdown
# H1
```

Current `@mdit/plugin-anchor` output:

```html
<h1 id="h1" tabindex="-1">H1 <a class="header-anchor" href="#h1" aria-hidden="true">#</a></h1>
```

markdown-it@14.3.0 + markdown-it-anchor@9.2.1 output (`anchor.permalink.ariaHidden({ ariaHidden: false })`):

```html
<h1 id="h1" tabindex="-1">H1 <a class="header-anchor" href="#h1">#</a></h1>
```

Fixed output matches upstream byte-for-byte.

### Root cause

`packages/plugin-anchor/src/permalink/ariaHidden.ts` does `linkInsideHeader({ ...opts, ariaHidden: true })` — user options are spread first and then overwritten. Upstream merges user options over the preset defaults (`Object.assign({}, renderPermalink.defaults, opts)` with `ariaHidden: true` only in the defaults), so the user value wins.

### Fix

Swap the spread order to `{ ariaHidden: true, ...opts }` so `ariaHidden: true` is the default and a user-supplied value takes precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
