### PR TITLE
fix(plugin-ruby): do not treat URL colons as ruby divider

### DIFF
--- a/packages/plugin-ruby/__tests__/ruby.spec.ts
+++ b/packages/plugin-ruby/__tests__/ruby.spec.ts
@@ -49,6 +49,27 @@ describe(ruby, () => {
         `<p><ruby><a href="//example.com">ruby base</a><rt>ruby text</rt></ruby></p>\n`,
       ],
       [
+        `{[ruby base](http://example.com):ruby text}`,
+        `<p><ruby><a href="http://example.com">ruby base</a><rt>ruby text</rt></ruby></p>\n`,
+      ],
+      [
+        `{[ruby base](http://example.com:8080):ruby text}`,
+        `<p><ruby><a href="http://example.com:8080">ruby base</a><rt>ruby text</rt></ruby></p>\n`,
+      ],
+      [
+        `{[ruby base](http://example.com/(v:1)):ruby text}`,
+        `<p><ruby><a href="http://example.com/(v:1)">ruby base</a><rt>ruby text</rt></ruby></p>\n`,
+      ],
+      [
+        `{[ruby base](http://example.com/a\\):b):ruby text}`,
+        `<p><ruby><a href="http://example.com/a):b">ruby base</a><rt>ruby text</rt></ruby></p>\n`,
+      ],
+      [
+        `{http://example.com:8080 :ruby text}`,
+        `<p><ruby><a href="http://example.com:8080">http://example.com:8080</a> <rt>ruby text</rt></ruby></p>\n`,
+      ],
+      [`{ruby base:/ruby text}`, `<p><ruby>ruby base<rt>/ruby text</rt></ruby></p>\n`],
+      [
         `{ruby base:[ruby text](http://example.com)}`,
         `<p><ruby>ruby base<rt><a href="http://example.com">ruby text</a></rt></ruby></p>\n`,
       ],
@@ -91,6 +112,21 @@ describe(ruby, () => {
       [`\\{ruby base:ruby text}`, `<p>{ruby base:ruby text}</p>\n`],
       [`{ruby base\\:ruby text}`, `<p>{ruby base:ruby text}</p>\n`],
       [`{ruby base|ruby text\\}`, `<p>{ruby base|ruby text}</p>\n`],
+      [`{http://example.com}`, `<p>{<a href="http://example.com">http://example.com</a>}</p>\n`],
+      // ruby text starting with "//" is indistinguishable from a URL scheme
+      [`{ruby base://ruby text}`, `<p>{ruby base://ruby text}</p>\n`],
+      [
+        `{[ruby base](http://example.com:8080}`,
+        `<p>{[ruby base](<a href="http://example.com:8080">http://example.com:8080</a>}</p>\n`,
+      ],
+      [
+        `{http://example.com:8080}`,
+        `<p>{<a href="http://example.com:8080">http://example.com:8080</a>}</p>\n`,
+      ],
+      [
+        `{http://example.com:8080`,
+        `<p>{<a href="http://example.com:8080">http://example.com:8080</a></p>\n`,
+      ],
     ];
 
     tests.forEach(([content, expected]) => {

--- a/packages/plugin-ruby/src/plugin.ts
+++ b/packages/plugin-ruby/src/plugin.ts
@@ -26,9 +26,42 @@ const rubyRule: RuleInline = (state, silent) => {
         break;
       }
     } else if (
+      state.src.charCodeAt(state.pos) === 93 /* ] */ &&
+      state.src.charCodeAt(state.pos - 1) !== 92 /* \ */ &&
+      state.src.charCodeAt(state.pos + 1) === 40 /* ( */
+    ) {
+      // colons inside a link destination are never dividers
+      let depth = 1;
+
+      state.pos += 2;
+
+      while (state.pos < max && depth) {
+        const code = state.src.charCodeAt(state.pos);
+
+        if (code === 92 /* \ */) state.pos++;
+        else if (code === 40 /* ( */) depth++;
+        else if (code === 41 /* ) */) depth--;
+
+        state.pos++;
+      }
+
+      continue;
+    } else if (
       state.src.charCodeAt(state.pos) === 58 /* : */ &&
       state.src.charCodeAt(state.pos - 1) !== 92 /* \ */
     ) {
+      if (state.src.startsWith("//", state.pos + 1)) {
+        // a `://` starts a bare URL - colons in the rest of its span are never dividers
+        while (
+          state.pos < max &&
+          state.src.charCodeAt(state.pos) !== 125 /* } */ &&
+          !state.md.utils.isWhiteSpace(state.src.charCodeAt(state.pos))
+        )
+          state.pos++;
+
+        continue;
+      }
+
       dividerPosition = state.pos;
     }
 


### PR DESCRIPTION
### Rationale

`@mdit/plugin-ruby` replaced markdown-it-ruby's `|` divider with `:`, but the divider scan takes the *first* unescaped `:` — including the one in `http://` — so a link with an absolute URL in the ruby base renders garbage. The equivalent fixture in markdown-it-ruby@1.1.2's own test suite (`{[ruby base](http://example.com)|ruby text}`) works fine, so users migrating that exact pattern get broken output.

### Repro

```js
import MarkdownIt from "markdown-it";
import { ruby } from "@mdit/plugin-ruby";

const md = MarkdownIt().use(ruby);
```

```md
{[ruby base](http://example.com):ruby text}
```

Current output:

```html
<p><ruby>[ruby base](http<rt>//example.com):ruby text</rt></ruby></p>
```

markdown-it@14.3.0 + markdown-it-ruby@1.1.2 output (its own `|` syntax, `{[ruby base](http://example.com)|ruby text}`):

```html
<p><ruby><a href="http://example.com">ruby base</a><rt>ruby text</rt></ruby></p>
```

Fixed output:

```html
<p><ruby><a href="http://example.com">ruby base</a><rt>ruby text</rt></ruby></p>
```

### Root cause

`packages/plugin-ruby/src/plugin.ts` — the raw scan marks the first unescaped `:` as the divider, and the `:` of `http://` inside the base text wins.

### Fix

Two rules when scanning for the divider: colons inside a markdown link destination (`](…)`, matched with paren-depth and escape handling) are never dividers — this also covers ports (`http://example.com:8080`), credentials, and IPv6 hosts — and a bare `://` starts a URL span that is skipped through to the next whitespace or `}`, so later colons in an autolinked URL (`{http://example.com:8080}`) are not dividers either. `{[ruby base](http\://example.com):ruby text}` already worked as a manual escape and still does.

This approach is open to discussion — the alternative is to keep the naive scan and document that URL colons must be escaped. Remaining trade-off: outside a link destination, a divider colon whose ruby text itself starts with `//` (`{ruby base://ruby text}`) is indistinguishable from an autolinked URL scheme, so it renders literally; a test pins this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



