### PR TITLE
fix(plugin-figure): keep tight list images intact

### DIFF
--- a/packages/plugin-figure/__tests__/figure.spec.ts
+++ b/packages/plugin-figure/__tests__/figure.spec.ts
@@ -61,6 +61,43 @@ test ![image](/logo.svg)
     );
   });
 
+  it("should not convert images in tight list items", () => {
+    expect(
+      markdownIt.render(`\
+- ![a](1.png "c1")
+- ![b](2.png "c2")
+`),
+    ).toBe(
+      `\
+<ul>
+<li><img src="1.png" alt="a" title="c1"></li>
+<li><img src="2.png" alt="b" title="c2"></li>
+</ul>
+`,
+    );
+  });
+
+  it("should convert images in loose list items", () => {
+    expect(
+      markdownIt.render(`\
+- ![a](1.png "c1")
+
+- ![b](2.png "c2")
+`),
+    ).toBe(
+      `\
+<ul>
+<li>
+<figure><img src="1.png" alt="a" tabindex="0"><figcaption>c1</figcaption></figure>
+</li>
+<li>
+<figure><img src="2.png" alt="b" tabindex="0"><figcaption>c2</figcaption></figure>
+</li>
+</ul>
+`,
+    );
+  });
+
   it("should handle empty caption", () => {
     expect(markdownIt.render("![](/logo.svg)")).toBe(
       '<figure><img src="/logo.svg" alt="" tabindex="0"><figcaption></figcaption></figure>\n',

--- a/packages/plugin-figure/src/plugin.ts
+++ b/packages/plugin-figure/src/plugin.ts
@@ -51,8 +51,10 @@ export const figure: PluginWithOptions<MarkdownItFigureOptions> = (md, options =
       }
 
       // check prev token is paragraph open and next token is paragraph close
+      // hidden paragraphs (tight lists) render no figure tags, which would orphan the figcaption
       if (
         state.tokens[index - 1].type !== "paragraph_open" ||
+        state.tokens[index - 1].hidden ||
         state.tokens[index + 1].type !== "paragraph_close"
       )
         continue;


### PR DESCRIPTION
### Rationale

In tight lists markdown-it emits *hidden* `paragraph_open`/`paragraph_close` tokens. The figure rule converts them to `figure_open`/`figure_close` anyway, but the `hidden` flag survives, so the figure tags render as nothing while the figcaption tokens injected into the inline children still render. The result is a `<figcaption>` directly inside `<li>` — invalid HTML (`figcaption` is only valid as a child of `figure`) — and the image's `title` attribute is silently consumed to produce it. The ancestor markdown-it-image-figures@2.1.1 has the same hidden-token flaw, but it only bites when users opt into its `figcaption` option; its default output for tight lists is clean, so a plain no-options migration turns valid output into invalid markup.

### Repro

```js
import MarkdownIt from "markdown-it";
import { figure } from "@mdit/plugin-figure";

const md = MarkdownIt().use(figure);
```

Input:

```md
- ![a](1.png "c1")
- ![b](2.png "c2")
```

Current output:

```html
<ul>
<li><img src="1.png" alt="a" tabindex="0"><figcaption>c1</figcaption></li>
<li><img src="2.png" alt="b" tabindex="0"><figcaption>c2</figcaption></li>
</ul>
```

markdown-it@14.3.0 + markdown-it-image-figures@2.1.1 output:

```html
<ul>
<li><img src="1.png" alt="a" title="c1"></li>
<li><img src="2.png" alt="b" title="c2"></li>
</ul>
```

Fixed output: identical to upstream. Loose lists (blank line between items) are unaffected — they keep rendering a proper `<figure>` inside `<li>`.

### Root cause

`packages/plugin-figure/src/plugin.ts`: the paragraph-open/close check around the inline token doesn't look at the `hidden` flag, so hidden paragraphs from tight list items get converted to figure tokens that never render.

### Fix

Skip the conversion when the surrounding paragraph is hidden, leaving tight-list images as plain images with their `title` intact — matching upstream's default output. An alternative would be to un-hide the converted figure tokens (wrapping every tight-list image in a real `<figure>`); that changes list rendering much more drastically, but it's open to discussion if captions inside tight lists are considered desirable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
