### PR TITLE
fix(plugin-attrs): make repeated attribute keys last-wins

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/blockEnd.spec.ts
@@ -78,6 +78,17 @@ const createDualRuleTests = (
         expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
       });
 
+      it(replaceDelimiters("should keep the last value of repeated keys {#a #b}", options), () => {
+        const testCases = [
+          ["text {#a #b}", '<p id="b">text</p>\n'],
+          ["text {key=1 key=2}", '<p key="2">text</p>\n'],
+        ];
+
+        testCases.forEach(([src, expected]) => {
+          expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
+        });
+      });
+
       it(
         replaceDelimiters(
           "should support classes, css-modules, identifiers and attributes in same {}",

--- a/packages/plugin-attrs/__tests__/rules/fence.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/fence.spec.ts
@@ -36,6 +36,13 @@ const createDualRuleTests = (
         expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
       });
 
+      it(replaceDelimiters("should keep the last value of repeated keys", options), () => {
+        const src = "```js {#a #b}\ncode\n```";
+        const expected = '<pre><code id="b" class="language-js">code\n</code></pre>\n';
+
+        expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
+      });
+
       it("should handle VuePress line numbers in code blocks", () => {
         // VuePress line numbers only work with {} delimiters
         // oxlint-disable-next-line vitest/no-conditional-in-test

--- a/packages/plugin-attrs/__tests__/rules/inline.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/inline.spec.ts
@@ -59,6 +59,13 @@ const createDualRuleTests = (
         expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
       });
 
+      it(replaceDelimiters("should keep the last value of repeated keys", options), () => {
+        const src = "**b**{.x}{key=1}{key=2}";
+        const expected = '<p><strong class="x" key="2">b</strong></p>\n';
+
+        expect(markdownIt.render(replaceDelimiters(src, options))).toBe(expected);
+      });
+
       it(
         replaceDelimiters(
           "should work with multiple inline code blocks in same paragraph",

--- a/packages/plugin-attrs/src/helper/addAttrs.ts
+++ b/packages/plugin-attrs/src/helper/addAttrs.ts
@@ -22,7 +22,7 @@ export const addAttrs = (
         break;
       }
       default: {
-        token.attrPush([key, value]);
+        token.attrSet(key, value);
       }
     }
   });


### PR DESCRIPTION
### Rationale

markdown-it-attrs 5.0.0 changed `addAttrs` to use `token.attrSet()` for non-`class`/`css-module` keys, so when a key appears multiple times the last occurrence wins. `@mdit/plugin-attrs` still uses `token.attrPush()` unconditionally, so repeated keys emit duplicate attributes — invalid HTML in which browsers honor the *first* value. Migrating users therefore get both invalid markup and a different effective attribute value than upstream.

### Repro

```js
import MarkdownIt from "markdown-it";
import { attrs } from "@mdit/plugin-attrs";

const md = MarkdownIt().use(attrs);
```

Input:

```markdown
text {#a #b}
```

Current `@mdit/plugin-attrs` output:

```html
<p id="a" id="b">text</p>
```

markdown-it@14.3.0 + markdown-it-attrs@5.0.1 output:

```html
<p id="b">text</p>
```

Fixed output matches upstream. Same shape for every rule, e.g. `text {key=1 key=2}` (`key="1" key="2"` vs upstream `key="2"`), inline `**b**{.x}{key=1}{key=2}` (`<strong class="x" key="1" key="2">` vs upstream `<strong class="x" key="2">`), fences ` ```js {#a #b} ` (`<code id="a" id="b" class="language-js">` vs upstream `id="b"`), and list items `- item{key=1 key=2}`. `class`/`css-module` keep merging via `attrJoin` on both sides (`{.a .a}` → `class="a a"`).

### Root cause

`packages/plugin-attrs/src/helper/addAttrs.ts` — the default branch uses `token.attrPush([key, value])`, appending a new attribute pair even when the key already exists on the token.

### Fix

Use `token.attrSet(key, value)` in the default branch, mirroring upstream 5.x semantics: last occurrence wins for regular keys, `class`/`css-module` still merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
