### PR TITLE
fix(plugin-ruby): split ruby base by code points

### DIFF
--- a/packages/plugin-ruby/__tests__/ruby.spec.ts
+++ b/packages/plugin-ruby/__tests__/ruby.spec.ts
@@ -17,6 +17,7 @@ describe(ruby, () => {
         `{鬼門:き|もん}の{方角:ほう|がく}を{凝視:ぎょう|し}する。`,
         `<p><ruby>鬼<rt>き</rt>門<rt>もん</rt></ruby>の<ruby>方<rt>ほう</rt>角<rt>がく</rt></ruby>を<ruby>凝<rt>ぎょう</rt>視<rt>し</rt></ruby>する。</p>\n`,
       ],
+      [`{𩸽鮭:ほっけ|さけ}`, `<p><ruby>𩸽<rt>ほっけ</rt>鮭<rt>さけ</rt></ruby></p>\n`],
       [`{編集者:editor}`, `<p><ruby>編集者<rt>editor</rt></ruby></p>\n`],
       [`{editor:エディター}`, `<p><ruby>editor<rt>エディター</rt></ruby></p>\n`],
     ];

--- a/packages/plugin-ruby/src/plugin.ts
+++ b/packages/plugin-ruby/src/plugin.ts
@@ -51,7 +51,7 @@ const rubyRule: RuleInline = (state, silent) => {
   const baseText = state.src.slice(start + 1, dividerPosition);
   const rubyText = state.src.slice(dividerPosition + 1, closePos);
 
-  const baseArray = baseText.split("");
+  const baseArray = Array.from(baseText);
   const rubyArray = rubyText.split("|");
 
   if (baseArray.length === rubyArray.length) {


### PR DESCRIPTION
### Rationale

markdown-it-ruby@1.1.2 splits the ruby base into characters with `Array.from` (code points), so per-character ruby works for non-BMP CJK characters — exactly the JIS X 0213 kanji (e.g. 𩸽 U+29E3D) that ruby annotations exist for. `@mdit/plugin-ruby` splits with `.split("")` (UTF-16 code units), so an astral character counts as two "characters", the length match against the ruby segments fails, and the input silently degrades to whole-text ruby with a literal `|` leaking into `<rt>`.

### Repro

```js
import MarkdownIt from "markdown-it";
import { ruby } from "@mdit/plugin-ruby";

const md = MarkdownIt().use(ruby);
```

```md
{𩸽鮭:ほっけ|さけ}
```

Current output:

```html
<p><ruby>𩸽鮭<rt>ほっけ|さけ</rt></ruby></p>
```

markdown-it@14.3.0 + markdown-it-ruby@1.1.2 output (its own `|` syntax, `{𩸽鮭|ほっけ|さけ}`):

```html
<p><ruby>𩸽<rt>ほっけ</rt>鮭<rt>さけ</rt></ruby></p>
```

Fixed output:

```html
<p><ruby>𩸽<rt>ほっけ</rt>鮭<rt>さけ</rt></ruby></p>
```

### Root cause

`packages/plugin-ruby/src/plugin.ts` — `baseText.split("")` yields UTF-16 code units, not code points, so surrogate pairs are counted twice when matching base length against the ruby segment count.

### Fix

Split the base with `Array.from(baseText)`, matching upstream. Whole-text ruby for astral bases (`{𩸽:ほっけ}`) already worked and is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
