### PR TITLE
fix(plugin-tex): skip unicode whitespace after block closers

### DIFF
--- a/packages/plugin-tex/__tests__/tex.spec.ts
+++ b/packages/plugin-tex/__tests__/tex.spec.ts
@@ -309,6 +309,20 @@ $$`),
         });
       });
 
+      describe("unicode whitespace after closing marker", () => {
+        const unicodeWhitespaceCases: [string, string][] = [
+          ["$$a=1$$\u3000\nfollowing", "<p>{Tex content: a=1}</p>\n<p>following</p>\n"],
+          ["$$\na=1\n$$\u00A0\nfollowing", "<p>{Tex content: a=1}</p>\n<p>following</p>\n"],
+        ];
+
+        it.for(unicodeWhitespaceCases)(
+          "should recognize closing marker: %s",
+          ([input, expected]) => {
+            expect(dollarModeMarkdownIt.render(input)).toStrictEqual(expected);
+          },
+        );
+      });
+
       it("should ignore bracket syntax", () => {
         expect(dollarModeMarkdownIt.render(String.raw`\[a=1\]`)).toBe("<p>[a=1]</p>\n");
       });
@@ -346,6 +360,20 @@ y = 2
         it.for(bracketRejectionCases)(
           "should not render when %s: %s",
           ([_description, input, expected]) => {
+            expect(bracketModeMarkdownIt.render(input)).toStrictEqual(expected);
+          },
+        );
+      });
+
+      describe("unicode whitespace after closing marker", () => {
+        const unicodeWhitespaceCases: [string, string][] = [
+          ["\\[a=1\\]\u3000\nfollowing", "<p>{Tex content: a=1}</p>\n<p>following</p>\n"],
+          ["\\[\na=1\n\\]\u00A0\nfollowing", "<p>{Tex content: a=1}</p>\n<p>following</p>\n"],
+        ];
+
+        it.for(unicodeWhitespaceCases)(
+          "should recognize closing marker: %s",
+          ([input, expected]) => {
             expect(bracketModeMarkdownIt.render(input)).toStrictEqual(expected);
           },
         );

--- a/packages/plugin-tex/src/plugin.ts
+++ b/packages/plugin-tex/src/plugin.ts
@@ -4,6 +4,7 @@ import type { Options, PluginWithOptions } from "markdown-it";
 import type { RuleBlock } from "markdown-it/lib/parser_block.mjs";
 import type { RuleInline } from "markdown-it/lib/parser_inline.mjs";
 import type Renderer from "markdown-it/lib/renderer.mjs";
+import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
 import type StateInline from "markdown-it/lib/rules_inline/state_inline.mjs";
 import type Token from "markdown-it/lib/token.mjs";
 
@@ -184,6 +185,16 @@ const createBracketInlineTexRule = (): RuleInline => (state, silent) => {
   return true;
 };
 
+// Like state.skipSpacesBack, but skips markdown-it's Unicode whitespace set (e.g. NBSP)
+const skipWhitespaceBack = (state: StateBlock, max: number, min: number): number => {
+  const isWhiteSpace = state.md.utils.isWhiteSpace;
+  let pos = max;
+
+  while (pos > min && isWhiteSpace(state.src.charCodeAt(pos - 1))) pos--;
+
+  return pos;
+};
+
 /*
  * Parse block math with dollar signs: $$...$$
  */
@@ -196,7 +207,7 @@ const dollarBlockTexRule: RuleBlock = (state, startLine, endLine, silent) => {
 
   if (silent) return true;
 
-  let contentEnd = state.skipSpacesBack(end, start);
+  let contentEnd = skipWhitespaceBack(state, end, start);
   let pos = start + 2;
   let firstLine: string;
   let found = false;
@@ -227,7 +238,7 @@ const dollarBlockTexRule: RuleBlock = (state, startLine, endLine, silent) => {
     if (pos < end && state.tShift[current] < state.blkIndent) break;
 
     // found end marker
-    contentEnd = state.skipSpacesBack(end, pos);
+    contentEnd = skipWhitespaceBack(state, end, pos);
 
     if (
       contentEnd - pos >= 2 &&
@@ -266,7 +277,7 @@ const bracketBlockTexRule: RuleBlock = (state, startLine, endLine, silent) => {
 
   if (silent) return true;
 
-  let contentEnd = state.skipSpacesBack(end, start);
+  let contentEnd = skipWhitespaceBack(state, end, start);
   let pos = start + 2;
   let firstLine: string;
   let found = false;
@@ -297,7 +308,7 @@ const bracketBlockTexRule: RuleBlock = (state, startLine, endLine, silent) => {
     if (pos < end && state.tShift[current] < state.blkIndent) break;
 
     // found end marker
-    contentEnd = state.skipSpacesBack(end, pos);
+    contentEnd = skipWhitespaceBack(state, end, pos);
 
     if (
       contentEnd - pos >= 2 &&


### PR DESCRIPTION
### Rationale

`markdown-it-katex@2.0.3` (the ancestor of this plugin) locates the closing `$$` of display math via `line.trim().slice(-2) === "$$"`, and `String.prototype.trim` strips all Unicode whitespace. `@mdit/plugin-tex` instead scans back with `state.skipSpacesBack`, which only skips space and tab. A trailing NBSP (U+00A0) or ideographic space (U+3000, easy to leave behind with CJK input methods) after the closing `$$` therefore hides the closer — and since the `$$` block self-closes at the end of the document, everything after it is swallowed into the math content and rendered as math. Documents that render fine with `markdown-it-katex` lose arbitrary trailing content on migration.

### Repro

```js
import MarkdownIt from "markdown-it";
import { tex } from "@mdit/plugin-tex";

// dummy renderer so the output shows recognition, not KaTeX markup
const md = MarkdownIt().use(tex, {
  render: (content, displayMode) =>
    displayMode ? `<math-block>${content}</math-block>\n` : `<math-inline>${content}</math-inline>`,
});

// NBSP after the closing $$; same result with U+3000, U+000B, U+000C
md.render("$$\n1+1\n$$\u00a0\nfollowing\n");
```

Current `@mdit/plugin-tex` output:

```html
<math-block>1+1
$$ 
following
</math-block>
```

markdown-it@14.3.0 + markdown-it-katex@2.0.3 output (identical dummy renderer; upstream behaves the same under markdown-it@6, so this is not markdown-it version noise):

```html
<math-block>1+1
</math-block>
<p>following</p>
```

Fixed `@mdit/plugin-tex` output matches upstream exactly. The single-line form regresses the same way (`"$$1+1$$\u3000\nfollowing\n"` swallows the following paragraph) and is likewise fixed.

### Root cause

`packages/plugin-tex/src/plugin.ts`, `dollarBlockTexRule`: closer detection back-scans trailing whitespace with `state.skipSpacesBack`, which handles only 0x20/0x09, while upstream's `trim()`-based detection accepts any Unicode whitespace after the marker.

### Fix

Back-scan with a small helper based on `md.utils.isWhiteSpace` (markdown-it's Unicode whitespace class, which covers the cases upstream handled via `trim()`) instead of `state.skipSpacesBack`. `bracketBlockTexRule` (`\[...\]`, a surface without an upstream counterpart) shares the identical pattern and bug, so it gets the same fix in this PR; tests cover single-line and multiline closers for both rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

