### PR TITLE
fix(plugin-img-size): accept newlines inside legacy image parens

### DIFF
--- a/packages/plugin-img-size/__tests__/legacyImgSize.spec.ts
+++ b/packages/plugin-img-size/__tests__/legacyImgSize.spec.ts
@@ -139,6 +139,39 @@ describe("legacy image size", () => {
         expect(markdownIt.render(input)).toStrictEqual(expected);
       });
     });
+
+    it("soft-wrapped", () => {
+      const testCases = [
+        [
+          `![image](\n/logo.svg =200x300)`,
+          '<p><img src="/logo.svg" alt="image" width="200" height="300"></p>\n',
+        ],
+        [
+          `![image](/logo.svg\n =200x300)`,
+          '<p><img src="/logo.svg" alt="image" width="200" height="300"></p>\n',
+        ],
+        [
+          `![image](/logo.svg \n =200x300)`,
+          '<p><img src="/logo.svg" alt="image" width="200" height="300"></p>\n',
+        ],
+        [
+          `![image](/logo.svg\n"title" =200x300)`,
+          '<p><img src="/logo.svg" alt="image" title="title" width="200" height="300"></p>\n',
+        ],
+        [
+          `![image](/logo.svg "title"\n =200x300)`,
+          '<p><img src="/logo.svg" alt="image" title="title" width="200" height="300"></p>\n',
+        ],
+        [
+          `![image](/logo.svg =200x300\n)`,
+          '<p><img src="/logo.svg" alt="image" width="200" height="300"></p>\n',
+        ],
+      ];
+
+      testCases.forEach(([input, expected]) => {
+        expect(markdownIt.render(input)).toStrictEqual(expected);
+      });
+    });
   });
 
   describe("should render with width or height", () => {

--- a/packages/plugin-img-size/src/legacy.ts
+++ b/packages/plugin-img-size/src/legacy.ts
@@ -78,6 +78,7 @@ const parseImageSize = (
 const legacyImgSizeRule: RuleInline = (state, silent) => {
   const env = state.env as ImgSizeEnv;
   const isSpace = state.md.utils.isSpace;
+  const isSpaceOrNewline = (code: number): boolean => isSpace(code) || code === 10; /* \n */
   const oldPos = state.pos;
   const max = state.posMax;
 
@@ -111,7 +112,7 @@ const legacyImgSizeRule: RuleInline = (state, silent) => {
     pos++;
 
     while (pos < max) {
-      if (!isSpace(state.src.charCodeAt(pos))) break;
+      if (!isSpaceOrNewline(state.src.charCodeAt(pos))) break;
 
       pos++;
     }
@@ -136,7 +137,7 @@ const legacyImgSizeRule: RuleInline = (state, silent) => {
     //                ^^ skipping these spaces
     const start = pos;
 
-    for (; pos < max; pos++) if (!isSpace(state.src.charCodeAt(pos))) break;
+    for (; pos < max; pos++) if (!isSpaceOrNewline(state.src.charCodeAt(pos))) break;
 
     // [link](  <href>  "title"  )
     //                  ^^^^^^^ parsing link title
@@ -151,7 +152,7 @@ const legacyImgSizeRule: RuleInline = (state, silent) => {
       // [link](  <href>  "title"  )
       //                         ^^ skipping these spaces
       for (; pos < max; pos++) {
-        if (!isSpace(state.src.charCodeAt(pos))) {
+        if (!isSpaceOrNewline(state.src.charCodeAt(pos))) {
           skipSpaces = true;
           break;
         }
@@ -169,7 +170,7 @@ const legacyImgSizeRule: RuleInline = (state, silent) => {
 
       // [link](  <href>  "title" =WxH  )
       //                              ^^ skipping these spaces
-      for (; pos < max; pos++) if (!isSpace(state.src.charCodeAt(pos))) break;
+      for (; pos < max; pos++) if (!isSpaceOrNewline(state.src.charCodeAt(pos))) break;
     }
 
     if (pos >= max || state.src.charCodeAt(pos) !== 41 /* ) */) {


### PR DESCRIPTION
### Rationale

`legacyImgSize` is a fork of `markdown-it-imsize`, but it rejects soft-wrapped image constructs that upstream accepts (verified on markdown-it 4 and 14). Core markdown-it itself allows newlines in exactly these positions inside link/image parens, so documents that soft-wrap long image lines are valid markdown — after migrating to `@mdit/plugin-img-size`, they silently degrade to literal text.

### Repro

```js
import MarkdownIt from "markdown-it";
import { legacyImgSize } from "@mdit/plugin-img-size";

const md = MarkdownIt().use(legacyImgSize);
```

Input:

```markdown
![test](x
 =1x2)
```

Current `@mdit/plugin-img-size` output:

```html
<p>![test](x
=1x2)</p>
```

markdown-it@14.3.0 + markdown-it-imsize@2.0.1 output:

```html
<p><img src="x" alt="test" width="1" height="2"></p>
```

Same with a title:

```markdown
![test](x
"title" =1x2)
```

Current output:

```html
<p>![test](x
&quot;title&quot; =1x2)</p>
```

markdown-it@14.3.0 + markdown-it-imsize@2.0.1 output:

```html
<p><img src="x" alt="test" title="title" width="1" height="2"></p>
```

Fixed output matches upstream byte-for-byte for both inputs (and for newlines after the title or the size spec).

### Root cause

`packages/plugin-img-size/src/legacy.ts` uses `md.utils.isSpace` (space + tab only) in the four whitespace-skipping loops inside the paren scan, while upstream's loops skip `0x20` and `0x0A`. A soft line break aborts the rule, and core's image rule then also fails on the trailing ` =WxH`, leaving literal text.

### Fix

The four loops (after `(`, after the destination, after the title, after the size spec) now also accept `0x0A`, which is the same whitespace set core's own link/image rules use for these positions. One side effect worth noting: since legacy mode already doesn't require upstream's literal space immediately before `=`, `![test](x\n=1x2)` (newline but no space before the size) now also parses as a sized image, where upstream kept it literal — strictly more permissive, but open to discussion if that gate should be enforced instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
