### PR TITLE
fix(plugin-dl): reject definition markers indented 4+ spaces

### DIFF
--- a/packages/plugin-dl/__tests__/dl.spec.ts
+++ b/packages/plugin-dl/__tests__/dl.spec.ts
@@ -145,6 +145,48 @@ Term 3
 </dl>
 `,
       ],
+      // Markers indented 4+ spaces are not definitions
+      [
+        `\
+Term 1
+   : definition
+
+Term 2
+    : not a definition
+`,
+        `\
+<dl>
+<dt>Term 1</dt>
+<dd>definition</dd>
+</dl>
+<p>Term 2
+: not a definition</p>
+`,
+      ],
+      // Tab-indented markers count as 4 spaces
+      [
+        `\
+Term
+\t: def
+`,
+        `\
+<p>Term
+: def</p>
+`,
+      ],
+      // Marker indentation is relative to the current block
+      [
+        `\
+- Term
+      : def
+`,
+        `\
+<ul>
+<li>Term
+: def</li>
+</ul>
+`,
+      ],
     ];
 
     testCases.forEach(([content, expected]) => {

--- a/packages/plugin-dl/__tests__/dl.spec.ts
+++ b/packages/plugin-dl/__tests__/dl.spec.ts
@@ -145,7 +145,179 @@ Term 3
 </dl>
 `,
       ],
-      // Markers indented 4+ spaces are not definitions
+    ];
+
+    testCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toStrictEqual(expected);
+    });
+  });
+
+  it("should detect marker indentation correctly", () => {
+    // Valid indents (0–3 spaces): marker is recognized as a definition
+    const validCases: [string, string][] = [
+      // 0-space indent
+      [
+        `\
+Term
+: Definition
+`,
+        `\
+<dl>
+<dt>Term</dt>
+<dd>Definition</dd>
+</dl>
+`,
+      ],
+      // 1-space indent
+      [
+        `\
+Term
+ : Definition
+`,
+        `\
+<dl>
+<dt>Term</dt>
+<dd>Definition</dd>
+</dl>
+`,
+      ],
+      // 2-space indent
+      [
+        `\
+Term
+  : Definition
+`,
+        `\
+<dl>
+<dt>Term</dt>
+<dd>Definition</dd>
+</dl>
+`,
+      ],
+      // 3-space indent
+      [
+        `\
+Term
+   : Definition
+`,
+        `\
+<dl>
+<dt>Term</dt>
+<dd>Definition</dd>
+</dl>
+`,
+      ],
+      // Mixed valid indents across terms
+      [
+        `\
+Term 1
+: Def 1
+
+Term 2
+ : Def 2
+
+Term 3
+  : Def 3
+
+Term 4
+   : Def 4
+`,
+        `\
+<dl>
+<dt>Term 1</dt>
+<dd>Def 1</dd>
+<dt>Term 2</dt>
+<dd>Def 2</dd>
+<dt>Term 3</dt>
+<dd>Def 3</dd>
+<dt>Term 4</dt>
+<dd>Def 4</dd>
+</dl>
+`,
+      ],
+    ];
+
+    validCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toStrictEqual(expected);
+    });
+
+    // Invalid indents (4+ spaces): marker is NOT recognized, treated as paragraph
+    const invalidCases: [string, string][] = [
+      // 4-space indent
+      [
+        `\
+Term
+    : not a definition
+`,
+        `\
+<p>Term
+: not a definition</p>
+`,
+      ],
+      // 5-space indent
+      [
+        `\
+Term
+     : not a definition
+`,
+        `\
+<p>Term
+: not a definition</p>
+`,
+      ],
+      // 6-space indent
+      [
+        `\
+Term
+      : not a definition
+`,
+        `\
+<p>Term
+: not a definition</p>
+`,
+      ],
+      // Tab indent (counts as 4)
+      [
+        `\
+Term
+\t: not a definition
+`,
+        `\
+<p>Term
+: not a definition</p>
+`,
+      ],
+      // No space after marker
+      [
+        `\
+Term
+:not a definition
+`,
+        `\
+<p>Term
+:not a definition</p>
+`,
+      ],
+      // Wrong marker character
+      [
+        `\
+Term
+; not a definition
+`,
+        `\
+<p>Term
+; not a definition</p>
+`,
+      ],
+    ];
+
+    invalidCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toStrictEqual(expected);
+    });
+
+    // Mixed valid and invalid indents in the same input
+    const boundaryCases: [string, string][] = [
+      // 3-space valid, 4-space invalid
       [
         `\
 Term 1
@@ -163,7 +335,7 @@ Term 2
 : not a definition</p>
 `,
       ],
-      // Tab-indented markers count as 4 spaces
+      // Tab indent (counts as 4) is invalid
       [
         `\
 Term
@@ -174,7 +346,7 @@ Term
 : def</p>
 `,
       ],
-      // Marker indentation is relative to the current block
+      // Indentation is relative to current block indent
       [
         `\
 - Term
@@ -185,6 +357,161 @@ Term
 <li>Term
 : def</li>
 </ul>
+`,
+      ],
+    ];
+
+    boundaryCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toStrictEqual(expected);
+    });
+  });
+
+  it("should correctly split definition lists on invalid markers", () => {
+    const testCases: [string, string][] = [
+      // Term 2 with 4-space indent breaks the list → 2 separate dl + a paragraph
+      [
+        `\
+Term 1
+: Def 1
+
+Term 2
+    : Wrong indent
+
+Term 3
+: Def 3
+`,
+        `\
+<dl>
+<dt>Term 1</dt>
+<dd>Def 1</dd>
+</dl>
+<p>Term 2
+: Wrong indent</p>
+<dl>
+<dt>Term 3</dt>
+<dd>Def 3</dd>
+</dl>
+`,
+      ],
+      // Term 2 with no space after marker breaks the list → 2 separate dl + a paragraph
+      [
+        `\
+Term 1
+: Def 1
+
+Term 2
+:bad marker
+
+Term 3
+: Def 3
+`,
+        `\
+<dl>
+<dt>Term 1</dt>
+<dd>Def 1</dd>
+</dl>
+<p>Term 2
+:bad marker</p>
+<dl>
+<dt>Term 3</dt>
+<dd>Def 3</dd>
+</dl>
+`,
+      ],
+      // Term 1 and 3 have different indent depths (0 and 3), both are valid
+      [
+        `\
+Term 1
+: Def 1
+
+Term 2
+   : Def 2
+
+Term 3
+: Def 3
+`,
+        `\
+<dl>
+<dt>Term 1</dt>
+<dd>Def 1</dd>
+<dt>Term 2</dt>
+<dd>Def 2</dd>
+<dt>Term 3</dt>
+<dd>Def 3</dd>
+</dl>
+`,
+      ],
+    ];
+
+    testCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toStrictEqual(expected);
+    });
+  });
+
+  it("should handle marker indentation relative to block context", () => {
+    const testCases: [string, string][] = [
+      // Inside a list: blkIndent is 2, so 6 spaces = 4 relative → not a dd
+      [
+        `\
+- Term
+      : not a definition
+`,
+        `\
+<ul>
+<li>Term
+: not a definition</li>
+</ul>
+`,
+      ],
+      // Inside a list: blkIndent is 2, so 5 spaces = 3 relative → valid dd
+      [
+        `\
+- Term
+     : definition
+`,
+        `\
+<ul>
+<li>
+<dl>
+<dt>Term</dt>
+<dd>definition</dd>
+</dl>
+</li>
+</ul>
+`,
+      ],
+      // Inside a blockquote: definition list is valid
+      [
+        `\
+> Term
+> : Definition
+`,
+        `\
+<blockquote>
+<dl>
+<dt>Term</dt>
+<dd>Definition</dd>
+</dl>
+</blockquote>
+`,
+      ],
+      // Inside a blockquote: lazy continuation is not a definition
+      [
+        `\
+> cherry
+> : keyboard company
+> pomegranate
+: tart fruit
+`,
+        `\
+<blockquote>
+<dl>
+<dt>cherry</dt>
+<dd>keyboard company
+pomegranate
+: tart fruit</dd>
+</dl>
+</blockquote>
 `,
       ],
     ];
@@ -638,6 +965,17 @@ Term
 <p>Term</p>
 `,
       ],
+      // Term followed by two empty lines
+      [
+        `\
+Term
+
+
+`,
+        `\
+<p>Term</p>
+`,
+      ],
       // Term 2 followed by a DD that is less indented than blkIndent
       [
         `\
@@ -688,7 +1026,8 @@ Term 1
 Term 2
 : Def 2
 `,
-        `<dl>
+        `\
+<dl>
 <dt>Term 1</dt>
 <dd>Def 1</dd>
 <dt>Term 2</dt>

--- a/packages/plugin-dl/src/plugin.ts
+++ b/packages/plugin-dl/src/plugin.ts
@@ -11,6 +11,7 @@ const checkAndSkipMarker = (state: StateBlock, line: number): number => {
   const max = state.eMarks[line];
 
   if (start >= max) return -1;
+  if (state.sCount[line] - state.blkIndent >= 4) return -1;
 
   // Check bullet
   const marker = state.src.charCodeAt(start++);


### PR DESCRIPTION
### Rationale

`markdown-it-deflist@4.0.0` limits definition-marker indentation to 3 spaces (Pandoc/CommonMark's usual "4 spaces = indented code" rule). `@mdit/plugin-dl` has no such cap, so markers indented 4+ spaces (or a tab, or deep inside a list item) still create definitions. Content written against upstream that uses extra indentation to *escape* deflist creation silently turns into a `<dl>` after migrating.

### Repro

```js
import MarkdownIt from "markdown-it";
import { dl } from "@mdit/plugin-dl";

const md = MarkdownIt({ linkify: true }).use(dl);
```

Input:

```markdown
Term 1
   : definition

Term 2
    : not a definition
```

Current `@mdit/plugin-dl` output:

```html
<dl>
<dt>Term 1</dt>
<dd>definition</dd>
<dt>Term 2</dt>
<dd>not a definition</dd>
</dl>
```

markdown-it@14.3.0 + markdown-it-deflist@4.0.0 output:

```html
<dl>
<dt>Term 1</dt>
<dd>definition</dd>
</dl>
<p>Term 2
: not a definition</p>
```

Fixed output matches upstream byte-for-byte, including the tab-indented variant (`Term\n\t: def` → paragraph) and markers deep inside list items (`- Term\n      : def` → plain `<li>` text, since the cap is relative to `blkIndent`).

### Root cause

`checkAndSkipMarker` in `packages/plugin-dl/src/plugin.ts` checks only for a `:`/`~` marker; it never looks at `state.sCount[line] - state.blkIndent`.

### Fix

Port upstream's rejection into the marker check: `if (state.sCount[line] - state.blkIndent >= 4) return -1;`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
