### PR TITLE
fix(plugin-ruby): ignore empty ruby text segments

### DIFF
--- a/packages/plugin-ruby/__tests__/ruby.spec.ts
+++ b/packages/plugin-ruby/__tests__/ruby.spec.ts
@@ -18,6 +18,8 @@ describe(ruby, () => {
         `<p><ruby>鬼<rt>き</rt>門<rt>もん</rt></ruby>の<ruby>方<rt>ほう</rt>角<rt>がく</rt></ruby>を<ruby>凝<rt>ぎょう</rt>視<rt>し</rt></ruby>する。</p>\n`,
       ],
       [`{𩸽鮭:ほっけ|さけ}`, `<p><ruby>𩸽<rt>ほっけ</rt>鮭<rt>さけ</rt></ruby></p>\n`],
+      [`{漢字:かん|じ|}`, `<p><ruby>漢<rt>かん</rt>字<rt>じ</rt></ruby></p>\n`],
+      [`{ruby base:||}`, `<p><ruby>ruby base<rt>||</rt></ruby></p>\n`],
       [`{編集者:editor}`, `<p><ruby>編集者<rt>editor</rt></ruby></p>\n`],
       [`{editor:エディター}`, `<p><ruby>editor<rt>エディター</rt></ruby></p>\n`],
     ];

--- a/packages/plugin-ruby/__tests__/ruby.spec.ts
+++ b/packages/plugin-ruby/__tests__/ruby.spec.ts
@@ -17,6 +17,7 @@ describe(ruby, () => {
         `{鬼門:き|もん}の{方角:ほう|がく}を{凝視:ぎょう|し}する。`,
         `<p><ruby>鬼<rt>き</rt>門<rt>もん</rt></ruby>の<ruby>方<rt>ほう</rt>角<rt>がく</rt></ruby>を<ruby>凝<rt>ぎょう</rt>視<rt>し</rt></ruby>する。</p>\n`,
       ],
+      [`{𩸽鮭:ほっけ|さけ}`, `<p><ruby>𩸽<rt>ほっけ</rt>鮭<rt>さけ</rt></ruby></p>\n`],
       [`{編集者:editor}`, `<p><ruby>編集者<rt>editor</rt></ruby></p>\n`],
       [`{editor:エディター}`, `<p><ruby>editor<rt>エディター</rt></ruby></p>\n`],
     ];

--- a/packages/plugin-ruby/src/plugin.ts
+++ b/packages/plugin-ruby/src/plugin.ts
@@ -51,7 +51,7 @@ const rubyRule: RuleInline = (state, silent) => {
   const baseText = state.src.slice(start + 1, dividerPosition);
   const rubyText = state.src.slice(dividerPosition + 1, closePos);
 
-  const baseArray = baseText.split("");
+  const baseArray = Array.from(baseText);
   const rubyArray = rubyText.split("|");
 
   if (baseArray.length === rubyArray.length) {

--- a/packages/plugin-ruby/src/plugin.ts
+++ b/packages/plugin-ruby/src/plugin.ts
@@ -52,7 +52,9 @@ const rubyRule: RuleInline = (state, silent) => {
   const rubyText = state.src.slice(dividerPosition + 1, closePos);
 
   const baseArray = Array.from(baseText);
-  const rubyArray = rubyText.split("|");
+  const rubyArray = rubyText.includes("|")
+    ? rubyText.split("|").filter((segment) => segment.length > 0)
+    : [rubyText];
 
   if (baseArray.length === rubyArray.length) {
     baseArray.forEach((content, index) => {


### PR DESCRIPTION
Stacked on #597 — review the last commit only.

### Rationale

markdown-it-ruby@1.1.2 filters empty `|`-separated segments out of the ruby text before matching against the base length, so a trailing `|` still yields clean per-character ruby. `@mdit/plugin-ruby` counts the empty segment, the lengths mismatch, and the input degrades to whole-text ruby with raw pipes visible in `<rt>`.

### Repro

```js
import MarkdownIt from "markdown-it";
import { ruby } from "@mdit/plugin-ruby";

const md = MarkdownIt().use(ruby);
```

```md
{漢字:かん|じ|}
```

Current output:

```html
<p><ruby>漢字<rt>かん|じ|</rt></ruby></p>
```

markdown-it@14.3.0 + markdown-it-ruby@1.1.2 output (its own `|` syntax, `{漢字|かん|じ|}`):

```html
<p><ruby>漢<rt>かん</rt>字<rt>じ</rt></ruby></p>
```

Fixed output:

```html
<p><ruby>漢<rt>かん</rt>字<rt>じ</rt></ruby></p>
```

### Root cause

`packages/plugin-ruby/src/plugin.ts` — `rubyText.split("|")` keeps empty segments, so the segment count no longer equals the base character count and the per-character branch is skipped.

### Fix

Filter empty segments before length-matching, same as upstream (`rubyText.split('|').filter(text => text.length > 0)`, applied only when the ruby text contains `|` so a lone empty ruby text keeps its current fallback). Upstream's follow-up bail when *all* segments are empty is deliberately not ported — it emits an unclosed `<ruby>` or throws mid-render there, while we keep producing balanced whole-text markup (`{ruby base:||}` is pinned in the tests). Side effect worth noting: `{ab:x|}` now falls back to whole-text ruby (`<ruby>ab<rt>x|</rt></ruby>`) exactly like upstream, instead of the previous accidental per-character split with an empty `<rt>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
