### PR TITLE
fix(plugin-attrs): keep paragraph text between hr markers and attrs

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/hr.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/hr.spec.ts
@@ -43,6 +43,14 @@ const createDualRuleTests = (
         });
       });
 
+      it(replaceDelimiters("should not convert when text follows the markers", options), () => {
+        const testCases = ["--- hello {#id}", "---abc {#id}", "---  {#id}"];
+
+        testCases.forEach((src) => {
+          expect(markdownIt.render(replaceDelimiters(src, options))).not.toContain("hr");
+        });
+      });
+
       it("should support multiple classes for <hr>", () => {
         const src = "--- {.a .b}";
         const expected = '<hr class="a b">\n';
@@ -77,3 +85,23 @@ createDualRuleTests(
   },
   "with [[ ]] delimiters",
 );
+
+describe("hr detection", () => {
+  const markdownIt = MarkdownIt().use(attrs);
+
+  it("should keep paragraph text between the markers and the attrs", () => {
+    const testCases = [
+      ["--- hello {#id}", '<p id="id">--- hello</p>\n'],
+      ["---abc {#id}", '<p id="id">---abc</p>\n'],
+      ["---  {#id}", '<p id="id">--- </p>\n'],
+    ];
+
+    testCases.forEach(([src, expected]) => {
+      expect(markdownIt.render(src)).toBe(expected);
+    });
+  });
+
+  it("should not convert mixed marker paragraphs", () => {
+    expect(markdownIt.render("-*-{#id}")).toBe('<p id="id">-*-</p>\n');
+  });
+});

--- a/packages/plugin-attrs/src/rules/hr.ts
+++ b/packages/plugin-attrs/src/rules/hr.ts
@@ -7,6 +7,7 @@ import { defineAttrRule } from "./types.js";
 
 export const createHrRule = (md: MarkdownIt, options: DelimiterConfig): AttrRule => {
   const isSpace = md.utils.isSpace;
+  const endDelimiterChecker = createDelimiterChecker(options, "end");
 
   return defineAttrRule({
     /** Horizontal rule --- {#id} */
@@ -41,7 +42,10 @@ export const createHrRule = (md: MarkdownIt, options: DelimiterConfig): AttrRule
 
           if (!isSpace(content.charCodeAt(pos - 1))) pos--;
 
-          return createDelimiterChecker(options, "end")(content);
+          const range = endDelimiterChecker(content);
+
+          // attrs must directly follow the marker run, or the transform would drop the extra text
+          return range !== false && range[0] - options.left.length === pos ? range : false;
         },
       },
       {


### PR DESCRIPTION
### Rationale

The hr rule converts any paragraph that *starts* with 3+ identical marker characters and *ends* with an attrs block into `<hr>`, silently discarding everything in between. markdown-it-attrs@5.0.1 only converts when the attrs directly follow the marker run (its pattern is `^ {0,3}[-*_]{3,} ?` + left delimiter), so migrating users lose paragraph content that upstream renders faithfully.

### Repro

```js
import MarkdownIt from "markdown-it";
import { attrs } from "@mdit/plugin-attrs";

const md = MarkdownIt().use(attrs);
```

Input:

```markdown
--- hello {#id}
```

Current `@mdit/plugin-attrs` output (the text `hello` is lost):

```html
<hr id="id">
```

markdown-it@14.3.0 + markdown-it-attrs@5.0.1 output:

```html
<p id="id">--- hello</p>
```

Fixed output matches upstream. Same for `---abc {#id}` (upstream `<p id="id">---abc</p>`, current `<hr id="id">`) and the cosmetic two-space case `---  {#id}` (upstream `<p id="id">--- </p>`, current `<hr id="id">`). Actual hrs (`---{#id}`, `--- {#id}`, `***`/`___`/`----` variants, indented up to 3 spaces) still convert, and mixed-marker `-*-{#id}` intentionally stays a paragraph (it is not a thematic break; upstream converting it is its own bug).

### Root cause

`packages/plugin-attrs/src/rules/hr.ts` — the content test computes the position right after the marker run (plus at most one space) but never compares it against where the trailing attrs start, so any text in between passes the test and is then dropped by the transform (`tokens.splice(index + 1, 2)`).

### Fix

Compare the delimiter start returned by the end-delimiter checker against the computed position and reject the match when anything else sits in between.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
