### PR TITLE
fix(plugin-anchor): pass resolved options to permalink generators

### DIFF
--- a/packages/plugin-anchor/__tests__/basic.spec.ts
+++ b/packages/plugin-anchor/__tests__/basic.spec.ts
@@ -3,6 +3,7 @@ import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
 import type { AnchorOptions } from "../src/options.js";
+import type { PermalinkGenerator } from "../src/permalink/types.js";
 import { anchor } from "../src/plugin.js";
 
 const md = (options?: AnchorOptions): MarkdownIt => MarkdownIt({ html: true }).use(anchor, options);
@@ -134,6 +135,26 @@ describe("getTokensText option", () => {
       }).render("# H1 ![image](link) `code` _em_"),
     ).toBe(
       '<h1 id="h1-image-em" tabindex="-1">H1 <img src="link" alt="image"> <code>code</code> <em>em</em></h1>\n',
+    );
+  });
+});
+
+describe("permalink option", () => {
+  it("should call custom permalink generators with defaults applied", () => {
+    const permalink: PermalinkGenerator = (_slug, anchorOpts, state, index): void => {
+      const { slugify } = anchorOpts;
+
+      state.tokens[index + 1].children?.push(
+        Object.assign(new state.Token("link_open", "a", 1), {
+          attrs: [["href", `#${slugify("Link Target")}`]],
+        }),
+        Object.assign(new state.Token("text", "", 0), { content: "#" }),
+        new state.Token("link_close", "a", -1),
+      );
+    };
+
+    expect(md({ level: 2, permalink }).render("# H1\n\n## H2")).toBe(
+      '<h1>H1</h1>\n<h2 id="h2" tabindex="-1">H2<a href="#link-target">#</a></h2>\n',
     );
   });
 });

--- a/packages/plugin-anchor/src/options.ts
+++ b/packages/plugin-anchor/src/options.ts
@@ -92,3 +92,13 @@ export interface AnchorOptions {
    */
   tabIndex?: string | number | false;
 }
+
+/**
+ * Anchor options with defaults applied, as received by permalink generators
+ *
+ * 应用默认值后的锚点选项，即永久链接生成器接收到的选项
+ */
+export type ResolvedAnchorOptions = AnchorOptions &
+  Required<
+    Pick<AnchorOptions, "getTokensText" | "level" | "slugify" | "tabIndex" | "uniqueSlugStartIndex">
+  >;

--- a/packages/plugin-anchor/src/permalink/types.ts
+++ b/packages/plugin-anchor/src/permalink/types.ts
@@ -1,5 +1,7 @@
 import type StateCore from "markdown-it/lib/rules_core/state_core.mjs";
 
+import type { ResolvedAnchorOptions } from "../options.js";
+
 /**
  * Permalink render href function
  *
@@ -21,7 +23,7 @@ export type RenderAttrs = (slug: string, state: StateCore) => Record<string, str
  */
 export type PermalinkGenerator = (
   slug: string,
-  options: PermalinkOptions,
+  options: ResolvedAnchorOptions,
   state: StateCore,
   index: number,
 ) => void;

--- a/packages/plugin-anchor/src/plugin.ts
+++ b/packages/plugin-anchor/src/plugin.ts
@@ -2,7 +2,7 @@ import type { PluginWithOptions } from "markdown-it";
 import type StateCore from "markdown-it/lib/rules_core/state_core.mjs";
 
 import { defaultGetTokensText, defaultSlugify } from "./defaults.js";
-import type { AnchorOptions } from "./options.js";
+import type { AnchorOptions, ResolvedAnchorOptions } from "./options.js";
 import { isLevelSelectedArray, isLevelSelectedNumber, uniqueSlug } from "./utils.js";
 
 export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void => {
@@ -16,6 +16,17 @@ export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void
     permalink,
     callback,
   } = options;
+
+  // Custom permalink generators receive the options with defaults applied,
+  // matching markdown-it-anchor
+  const resolvedOptions: ResolvedAnchorOptions = {
+    ...options,
+    level,
+    slugify,
+    uniqueSlugStartIndex,
+    tabIndex,
+    getTokensText,
+  };
 
   md.core.ruler.push("anchor", (state: StateCore): void => {
     const slugs: Record<string, boolean> = {};
@@ -51,8 +62,7 @@ export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void
 
       if (tabIndex !== false) token.attrSet("tabindex", `${tabIndex}`);
 
-      if (typeof permalink === "function")
-        permalink(slug, options as Record<string, unknown>, state, index);
+      if (typeof permalink === "function") permalink(slug, resolvedOptions, state, index);
 
       // A permalink renderer could modify the `tokens` array so
       // make sure to get the up-to-date index on each iteration.

--- a/packages/plugin-anchor/src/plugin.ts
+++ b/packages/plugin-anchor/src/plugin.ts
@@ -5,28 +5,27 @@ import { defaultGetTokensText, defaultSlugify } from "./defaults.js";
 import type { AnchorOptions, ResolvedAnchorOptions } from "./options.js";
 import { isLevelSelectedArray, isLevelSelectedNumber, uniqueSlug } from "./utils.js";
 
-export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void => {
-  const {
-    level = 1,
-    slugify = defaultSlugify,
-    slugifyWithState,
-    uniqueSlugStartIndex = 1,
-    tabIndex = "-1",
-    getTokensText = defaultGetTokensText,
-    permalink,
-    callback,
-  } = options;
+const DEFAULTS = {
+  getTokensText: defaultGetTokensText,
+  level: 1,
+  slugify: defaultSlugify,
+  tabIndex: "-1",
+  uniqueSlugStartIndex: 1,
+};
 
-  // Custom permalink generators receive the options with defaults applied,
-  // matching markdown-it-anchor
-  const resolvedOptions: ResolvedAnchorOptions = {
-    ...options,
+export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void => {
+  const resolvedOptions = Object.assign({}, DEFAULTS, options) as ResolvedAnchorOptions;
+
+  const {
     level,
     slugify,
+    slugifyWithState,
     uniqueSlugStartIndex,
     tabIndex,
     getTokensText,
-  };
+    permalink,
+    callback,
+  } = resolvedOptions;
 
   md.core.ruler.push("anchor", (state: StateCore): void => {
     const slugs: Record<string, boolean> = {};


### PR DESCRIPTION
### Rationale

In markdown-it-anchor@9.2.1, a custom `permalink` function receives the fully merged anchor options as its second argument (`opts.slugify`, `opts.tabIndex`, `opts.getTokensText`, `opts.uniqueSlugStartIndex`, ... are always populated, since the plugin runs on `Object.assign({}, anchor.defaults, opts)`). `@mdit/plugin-anchor` passes the raw user options object instead, so a custom permalink generator migrated from markdown-it-anchor that reads a defaulted option throws or silently misbehaves.

### Repro

```js
import MarkdownIt from "markdown-it";
import { anchor } from "@mdit/plugin-anchor";

// a migrated custom permalink generator that relies on the resolved anchor options
const permalink = (slug, anchorOpts, state, index) => {
  const href = `#${anchorOpts.slugify(`${slug} link`)}`;

  state.tokens[index + 1].children.push(
    Object.assign(new state.Token("link_open", "a", 1), { attrs: [["href", href]] }),
    Object.assign(new state.Token("text", "", 0), { content: "#" }),
    new state.Token("link_close", "a", -1),
  );
};

const md = MarkdownIt({ html: true }).use(anchor, { level: 2, permalink });
```

Input:

```markdown
# H1

## H2
```

Current `@mdit/plugin-anchor`:

```
TypeError: anchorOpts.slugify is not a function
```

markdown-it@14.3.0 + markdown-it-anchor@9.2.1 output (same generator):

```html
<h1>H1</h1>
<h2 id="h2" tabindex="-1">H2<a href="#h2-link">#</a></h2>
```

Fixed output matches upstream byte-for-byte.

### Root cause

`packages/plugin-anchor/src/plugin.ts` calls `permalink(slug, options as Record<string, unknown>, state, index)` with the raw user options, after having already destructured the defaults into locals — the defaults never reach the generator. Upstream calls `opts.permalink(slug, opts, state, idx)` on the merged object.

### Fix

Build a `resolvedOptions` object (user options with the destructured defaults applied) and pass that to custom permalink generators. The `PermalinkGenerator` options parameter is now typed as `ResolvedAnchorOptions` (anchor options with the defaulted keys required), so the public type reflects what generators actually receive. Note the resolved object only contains options `@mdit/plugin-anchor` implements — upstream's legacy `permalink*`/`renderPermalink` default keys don't exist here, which is consistent with that surface being intentionally dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

