### PR TITLE
fix(plugin-attrs): support headerless tables

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/table.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/table.spec.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from "markdown-it";
+import multimdTable from "markdown-it-multimd-table";
 import { describe, expect, it } from "vitest";
 
 import type { MarkdownItAttrsOptions } from "../../src/index.js";
@@ -672,3 +673,33 @@ createDualRuleTests(
   },
   "with [[ ]] delimiters",
 );
+
+describe("headerless tables", () => {
+  it("should support tables without thead", () => {
+    const markdownIt = MarkdownIt().use(multimdTable, { headerless: true }).use(attrs);
+
+    const src = `\
+| - | - |
+| a | b |
+| c | d |
+{a=b}
+`;
+
+    const expected = `\
+<table a="b">
+<tbody>
+<tr>
+<td>a</td>
+<td>b</td>
+</tr>
+<tr>
+<td>c</td>
+<td>d</td>
+</tr>
+</tbody>
+</table>
+`;
+
+    expect(markdownIt.render(src)).toBe(expected);
+  });
+});

--- a/packages/plugin-attrs/package.json
+++ b/packages/plugin-attrs/package.json
@@ -53,7 +53,8 @@
     "@mdit/plugin-figure": "workspace:*",
     "@mdit/plugin-katex": "workspace:*",
     "@mdit/plugin-mark": "workspace:*",
-    "@mdit/plugin-tasklist": "workspace:*"
+    "@mdit/plugin-tasklist": "workspace:*",
+    "markdown-it-multimd-table": "^4.2.3"
   },
   "peerDependencies": {
     "markdown-it": "^14.2.0"

--- a/packages/plugin-attrs/src/rules/table.ts
+++ b/packages/plugin-attrs/src/rules/table.ts
@@ -185,8 +185,8 @@ export const createTableRules = (md: MarkdownIt, options: DelimiterConfig): Attr
 
         const tbodyOpenToken: TokenWithColumnCount = tokens[tbodyOpenIndex];
 
-        // oxlint-disable-next-line typescript/no-non-null-assertion
-        const columnCount = tbodyOpenToken.meta!.columnCount!;
+        // meta is missing when another plugin produced a headerless table (no thead)
+        const columnCount = tbodyOpenToken.meta?.columnCount ?? 0;
 
         if (columnCount < 2) return;
 

--- a/packages/plugin-attrs/src/rules/table.ts
+++ b/packages/plugin-attrs/src/rules/table.ts
@@ -185,7 +185,11 @@ export const createTableRules = (md: MarkdownIt, options: DelimiterConfig): Attr
 
         const tbodyOpenToken: TokenWithColumnCount = tokens[tbodyOpenIndex];
 
-        // meta is missing when another plugin produced a headerless table (no thead)
+        // oxlint-disable-next-line no-warning-comments
+        // FIXME: this is a workaround for markdown-it-multimd-table ONLY, which fails to
+        // produce markdown-it compatible tokens without columnCount
+        // Ref: https://github.com/redbug312/markdown-it-multimd-table/issues/81
+        // const columnCount = tbodyOpenToken.meta!.columnCount!;
         const columnCount = tbodyOpenToken.meta?.columnCount ?? 0;
 
         if (columnCount < 2) return;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -464,6 +464,9 @@ importers:
       '@mdit/plugin-tasklist':
         specifier: workspace:*
         version: link:../plugin-tasklist
+      markdown-it-multimd-table:
+        specifier: ^4.2.3
+        version: 4.2.3
 
   packages/plugin-container:
     dependencies:
@@ -3813,6 +3816,9 @@ packages:
 
   markdown-it-emoji@3.1.0:
     resolution: {integrity: sha512-NhmMEH2ywduD4Nty1E8uB5NqfLhAT1VR0dyvoJyStKOqCzbZmVdn/+8wj7zpDsb/fLBikpCPsWwxqKlvMmbz4g==}
+
+  markdown-it-multimd-table@4.2.3:
+    resolution: {integrity: sha512-KepCr2OMJqm7IT6sOIbuqHGe+NERhgy66XMrc5lo6dHW7oaPzMDtYwR1EGwK16/blb6mCSg4jqityOe0o/H7HA==}
 
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
@@ -8346,6 +8352,8 @@ snapshots:
       '@types/markdown-it': 14.1.2
 
   markdown-it-emoji@3.1.0: {}
+
+  markdown-it-multimd-table@4.2.3: {}
 
   markdown-it@14.3.0:
     dependencies:


### PR DESCRIPTION
### Rationale

`md.render()` throws on tables that have no `<thead>`, as produced by markdown-it-multimd-table with `{ headerless: true }` — with or without an attrs block in the document. markdown-it-attrs@5.0.1 renders these tables fine (it reads the column count defensively), so this is a hard crash for migrating users whose pipelines combine the two plugins.

### Repro

```js
import MarkdownIt from "markdown-it";
import multimdTable from "markdown-it-multimd-table";
import { attrs } from "@mdit/plugin-attrs";

const md = MarkdownIt().use(multimdTable, { headerless: true }).use(attrs);
```

Input:

```markdown
| - | - |
| a | b |
| c | d |
{a=b}
```

Current `@mdit/plugin-attrs`:

```
TypeError: Cannot read properties of null (reading 'columnCount')
```

markdown-it@14.3.0 + markdown-it-attrs@5.0.1 + markdown-it-multimd-table@4.2.3 output:

```html
<table a="b">
<tbody>
<tr>
<td>a</td>
<td>b</td>
</tr>
<tr>
<td>c</td>
<td>d</td>
</tr>
</tbody>
</table>
```

Fixed output is byte-identical to upstream's.

### Root cause

`packages/plugin-attrs/src/rules/table.ts` — the "table tbody calculate" rule reads `tbodyOpenToken.meta!.columnCount!`, but that meta is only set by the "table thead metadata" rule, which requires a `thead_close`/`tbody_open` sequence. With no thead the meta was never written, so the read explodes. Upstream 5.x guards the same read (`(tokens[idx].meta && tokens[idx].meta.colsnum) >> 0`).

### Fix

Read the column count with optional chaining and fall back to 0, which takes the existing `columnCount < 2` early return. markdown-it-multimd-table is added as a devDependency to pin the headerless rendering in the test suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
