### PR TITLE
fix(plugin-dl): apply compactness per definition term

### DIFF
--- a/packages/plugin-dl/__tests__/dl.spec.ts
+++ b/packages/plugin-dl/__tests__/dl.spec.ts
@@ -182,9 +182,7 @@ Complex Term
 <p>bar</p>
 </blockquote>
 </dd>
-<dd>
-<p>baz</p>
-</dd>
+<dd>baz</dd>
 <dt>Complex Term</dt>
 <dd>
 <p>Definition with list:</p>
@@ -288,6 +286,7 @@ Term 2
 </dl>
 `,
       ],
+      // Blank lines between definitions do not make terms loose
       [
         `\
 Term 1
@@ -302,19 +301,52 @@ Term 2
         `\
 <dl>
 <dt>Term 1</dt>
-<dd>
-<p>foo</p>
-</dd>
-<dd>
-<p>bar</p>
-</dd>
+<dd>foo</dd>
+<dd>bar</dd>
+<dt>Term 2</dt>
+<dd>foo</dd>
+<dd>bar</dd>
+</dl>
+`,
+      ],
+      // Blank line after a term makes only its own definitions loose
+      [
+        `\
+Term 1
+: foo
+
+Term 2
+
+: bar
+`,
+        `\
+<dl>
+<dt>Term 1</dt>
+<dd>foo</dd>
 <dt>Term 2</dt>
 <dd>
-<p>foo</p>
-</dd>
-<dd>
 <p>bar</p>
 </dd>
+</dl>
+`,
+      ],
+      [
+        `\
+Term 1
+
+: foo
+
+Term 2
+: bar
+`,
+        `\
+<dl>
+<dt>Term 1</dt>
+<dd>
+<p>foo</p>
+</dd>
+<dt>Term 2</dt>
+<dd>bar</dd>
 </dl>
 `,
       ],
@@ -351,28 +383,18 @@ Final Term
 <p>bar
 Term 2</p>
 </dd>
-<dd>
-<p>foo</p>
-</dd>
+<dd>foo</dd>
 <dt>Simple Term</dt>
-<dd>
-<p>Definition 1</p>
-</dd>
+<dd>Definition 1</dd>
 <dt>Another Term</dt>
 <dd>
 <p>Another definition</p>
 </dd>
 <dt>Mixed Term</dt>
-<dd>
-<p>Definition 1a</p>
-</dd>
-<dd>
-<p>Definition 1b</p>
-</dd>
+<dd>Definition 1a</dd>
+<dd>Definition 1b</dd>
 <dt>Final Term</dt>
-<dd>
-<p>Definition 2</p>
-</dd>
+<dd>Definition 2</dd>
 </dl>
 `,
       ],
@@ -670,6 +692,22 @@ Not a DD
 </dl>
 <p>Term 2
 Not a DD</p>
+`,
+      ],
+      // Definition containing only a reference produces no tokens
+      [
+        `\
+Term
+: [foo]: /url
+
+[foo]
+`,
+        `\
+<dl>
+<dt>Term</dt>
+<dd></dd>
+</dl>
+<p><a href="/url">foo</a></p>
 `,
       ],
       // Marker followed by only spaces

--- a/packages/plugin-dl/src/plugin.ts
+++ b/packages/plugin-dl/src/plugin.ts
@@ -30,16 +30,21 @@ const checkAndSkipMarker = (state: StateBlock, line: number): number => {
   return start;
 };
 
-const markTightParagraphs = (state: StateBlock, index: number): void => {
-  const level = state.level + 2;
+const markTightParagraph = (state: StateBlock, start: number, end: number, level: number): void => {
+  let block = -1;
 
-  for (let i = index + 2, length = state.tokens.length - 2; i < length; i++) {
-    if (state.tokens[i].level === level && state.tokens[i].type === "paragraph_open") {
-      state.tokens[i + 2].hidden = true;
-      state.tokens[i].hidden = true;
-      i += 2;
-    }
+  for (let i = start; i < end; i++) {
+    const token = state.tokens[i];
+
+    if (token.level !== level || token.nesting < 0) continue;
+    if (block >= 0) return;
+    block = i;
   }
+
+  if (block < 0 || state.tokens[block].type !== "paragraph_open") return;
+
+  state.tokens[block + 2].hidden = true;
+  state.tokens[block].hidden = true;
 };
 
 const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
@@ -54,11 +59,11 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
 
   if (nextLine >= endLine) return false;
 
-  let hasSkippedEmptyLines = false;
+  let termIsTight = true;
 
   if (state.isEmpty(nextLine)) {
     nextLine++;
-    hasSkippedEmptyLines = true;
+    termIsTight = false;
     if (nextLine >= endLine) return false;
   }
 
@@ -69,8 +74,6 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
   if (contentStart < 0) return false;
 
   // Start list
-  const listTokenIndex = state.tokens.length;
-
   const dlOpenToken = state.push("dl_open", "dl", 1);
   const listLines: [start: number, end: number] = [startLine, 0];
 
@@ -82,7 +85,6 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
 
   let dtLine = startLine;
   let ddLine = nextLine;
-  let tight = !hasSkippedEmptyLines;
 
   // One definition list can contain multiple DTs,
   // and one DT can be followed by multiple DDs.
@@ -92,8 +94,6 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
   //
   // oxlint-disable-next-line no-labels
   OUTER: for (;;) {
-    let prevEmptyEnd = false;
-
     const dtOpenToken = state.push("dt_open", "dt", 1);
 
     dtOpenToken.map = [dtLine, dtLine];
@@ -107,6 +107,8 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
     state.push("dt_close", "dt", -1);
 
     for (;;) {
+      const itemTokenIndex = state.tokens.length;
+
       const ddOpenToken = state.push("dd_open", "dd", 1);
       const itemLines: [start: number, end: number] = [nextLine, 0];
 
@@ -145,12 +147,8 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
       // @ts-expect-error: An internal param is used
       state.md.block.tokenize(state, ddLine, endLine, true);
 
-      // If any of list item is tight, mark list as tight
-      if (!state.tight || prevEmptyEnd) tight = false;
-
-      // Item become loose if finish with empty line,
-      // but we should filter last element, because it means list finish
-      prevEmptyEnd = state.line - ddLine > 1 && state.isEmpty(state.line - 1);
+      if (termIsTight)
+        markTightParagraph(state, itemTokenIndex, state.tokens.length, ddOpenToken.level + 1);
 
       state.tShift[ddLine] = oldTShift;
       state.sCount[ddLine] = oldSCount;
@@ -184,13 +182,17 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
 
     if (ddLine >= endLine) break;
 
-    if (state.isEmpty(ddLine)) ddLine++;
+    const skippedEmptyLine = state.isEmpty(ddLine);
+
+    if (skippedEmptyLine) ddLine++;
 
     if (ddLine >= endLine || state.sCount[ddLine] < state.blkIndent) break;
 
     contentStart = checkAndSkipMarker(state, ddLine);
 
     if (contentStart < 0) break;
+
+    termIsTight = !skippedEmptyLine;
 
     // go to the next loop iteration:
     // insert DT and DD tags and repeat checking
@@ -202,9 +204,6 @@ const dlRule: RuleBlock = (state, startLine, endLine, silent) => {
   listLines[1] = nextLine;
 
   state.line = nextLine;
-
-  // mark paragraphs tight if needed
-  if (tight) markTightParagraphs(state, listTokenIndex);
 
   return true;
 };


### PR DESCRIPTION
### Rationale

`markdown-it-deflist@4.0.0` computes compactness separately for each definition term; `@mdit/plugin-dl` keeps one tight flag for the whole list plus a global paragraph-hiding pass. The visible effect is `<p>` wrappers (and thus paragraph margins) diverging in both directions for migrating users:

- a blank line between two definitions wrongly loosens the entire list;
- a blank line after a later term fails to loosen that term's definitions — contradicting the plugin's own docs ("If there is a blank line after the term, the definition text will be treated as a paragraph");
- a blank line after the *first* term leaks looseness into every later term — the one case where the current output matches neither markdown-it-deflist@4.0.0 nor 3.0.1.

### Repro

```js
import MarkdownIt from "markdown-it";
import { dl } from "@mdit/plugin-dl";

const md = MarkdownIt({ linkify: true }).use(dl);
```

Input (blank line after a later term):

```markdown
Term 1
: foo

Term 2

: bar
```

Current `@mdit/plugin-dl` output:

```html
<dl>
<dt>Term 1</dt>
<dd>foo</dd>
<dt>Term 2</dt>
<dd>bar</dd>
</dl>
```

markdown-it@14.3.0 + markdown-it-deflist@4.0.0 output (fixed output matches):

```html
<dl>
<dt>Term 1</dt>
<dd>foo</dd>
<dt>Term 2</dt>
<dd>
<p>bar</p>
</dd>
</dl>
```

Input (blank line after the first term):

```markdown
Term 1

: foo

Term 2
: bar
```

Current `@mdit/plugin-dl` output (everything loose):

```html
<dl>
<dt>Term 1</dt>
<dd>
<p>foo</p>
</dd>
<dt>Term 2</dt>
<dd>
<p>bar</p>
</dd>
</dl>
```

markdown-it@14.3.0 + markdown-it-deflist@4.0.0 output (fixed output matches):

```html
<dl>
<dt>Term 1</dt>
<dd>
<p>foo</p>
</dd>
<dt>Term 2</dt>
<dd>bar</dd>
</dl>
```

### Root cause

`packages/plugin-dl/src/plugin.ts` tracks a single list-wide `tight` flag (fed by `state.tight` read-back and `prevEmptyEnd`) and unwraps paragraphs across the whole list at once in `markTightParagraphs`, so one term's spacing decides every term's rendering.

### Fix

Port upstream 4.0.0's per-term model: a `termIsTight` flag set from the blank line after each term, and a per-`<dd>` `markTightParagraph` that unwraps the paragraph only when the definition consists of exactly one. Existing tests pinning the whole-list behavior (blank-line-between-definitions rendering everything loose, and the mixed spacing-patterns case) were updated to the per-term expectations, each verified verbatim against markdown-it-deflist@4.0.0 on markdown-it@14.3.0 — every input in the updated spec now renders byte-identical to upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
