### PR TITLE
fix(plugin-abbr): trim all whitespace around definition titles

### DIFF
--- a/packages/plugin-abbr/__tests__/abbr.spec.ts
+++ b/packages/plugin-abbr/__tests__/abbr.spec.ts
@@ -200,4 +200,29 @@ test <abbr title="foo bar"> </abbr> test <abbr title="foo bar"> </abbr> test</p>
 <p>(foo bar)</p>
 `);
   });
+
+  it("should trim non-space whitespace around titles", () => {
+    expect(
+      markdownIt.render(`\
+*[HTML]: \u00A0Hyper Text\u00A0
+
+HTML
+`),
+    ).toBe(`\
+<p><abbr title="Hyper Text">HTML</abbr></p>
+`);
+  });
+
+  it("should not process whitespace-only titles", () => {
+    expect(
+      markdownIt.render(`\
+*[HTML]: \u00A0
+
+HTML is cool
+`),
+    ).toBe(`\
+<p>*[HTML]: \u00A0</p>
+<p>HTML is cool</p>
+`);
+  });
 });

--- a/packages/plugin-abbr/src/plugin.ts
+++ b/packages/plugin-abbr/src/plugin.ts
@@ -54,10 +54,8 @@ const abbrDefinition: RuleBlock = (state: AbbrStateBlock, startLine, _endLine, s
 
   const label = state.src.slice(labelStart, labelEnd).replaceAll(ESCAPE_RE, "$<char>");
 
-  pos = labelEnd + 2;
-  const titleStart = state.skipSpaces(pos);
-  const titleEnd = state.skipSpacesBack(max, titleStart);
-  const title = state.src.slice(titleStart, titleEnd);
+  // .trim() strips all JS whitespace (not just space/tab), matching markdown-it-abbr
+  const title = state.src.slice(labelEnd + 2, max).trim();
 
   if (label.length === 0 || title.length === 0) return false;
 


### PR DESCRIPTION
### Rationale

`markdown-it-abbr@2.0.0` extracts the definition title with `String.prototype.trim()`, which strips all JS whitespace. The perf refactor in c9bfd794 replaced that with `state.skipSpaces` / `state.skipSpacesBack`, which only strip space and tab. Two user-visible regressions for anyone migrating from `markdown-it-abbr`:

1. Exotic whitespace (NBSP, form feed, vertical tab, Unicode spaces) at the edges of a title survives into the rendered `title` attribute.
2. A title consisting only of such characters now counts as non-empty, so the definition is accepted and the line consumed, where upstream rejects the definition and renders the line literally. You can end up with an `<abbr>` whose title is invisible whitespace, and the definition line silently disappears.

### Repro

The fenced blocks below contain real U+00A0 (NBSP) characters; each input is also given as a JS string so the invisible characters are explicit.

```js
import MarkdownIt from "markdown-it";
import { abbr } from "@mdit/plugin-abbr";

const md = new MarkdownIt({ linkify: true }).use(abbr);
```

Input 1 — NBSP-padded title (`"*[HTML]: \u00a0Hyper Text\u00a0\n\nHTML\n"`):

```markdown
*[HTML]:  Hyper Text 

HTML
```

Current `@mdit/plugin-abbr` output (NBSP kept inside the attribute):

```html
<p><abbr title=" Hyper Text ">HTML</abbr></p>
```

markdown-it@14.3.0 + markdown-it-abbr@2.0.0 output:

```html
<p><abbr title="Hyper Text">HTML</abbr></p>
```

Input 2 — NBSP-only title (`"*[HTML]: \u00a0\n\nHTML is cool\n"`):

```markdown
*[HTML]:  

HTML is cool
```

Current `@mdit/plugin-abbr` output (definition accepted with a whitespace-only title):

```html
<p><abbr title=" ">HTML</abbr> is cool</p>
```

markdown-it@14.3.0 + markdown-it-abbr@2.0.0 output (definition rejected, line kept):

```html
<p>*[HTML]:  </p>
<p>HTML is cool</p>
```

With this PR both inputs render byte-identically to upstream.

### Root cause

`packages/plugin-abbr/src/plugin.ts` (`abbrDefinition`): c9bfd794 swapped upstream's `state.src.slice(labelEnd + 2, max).trim()` for `skipSpaces`/`skipSpacesBack` bounds, which are space/tab-only (markdown-it `isSpace`).

### Fix

Slice the title once and `.trim()` it, restoring upstream semantics (whitespace-only titles are rejected again). One could argue the space/tab-only behavior is more consistent with markdown-it core (reference-definition titles keep NBSP, for example), so if that reading is preferred this is open to discussion — but the change arrived undocumented and untested inside a perf refactor, so parity with `markdown-it-abbr` seems like the safer default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
