### PR TITLE
fix(plugin-container): restore upstream closing marker indent tolerance

### DIFF
--- a/packages/plugin-container/__tests__/container.spec.ts
+++ b/packages/plugin-container/__tests__/container.spec.ts
@@ -86,27 +86,50 @@ test
   });
 
   it("support nesting", () => {
-    const content = `
+    const testCases = [
+      [
+        `
 ::::: test
 :::: test
 xxx
 ::::
 :::::
-`;
-
-    expect(markdownIt.render(content)).toBe(
-      `\
+`,
+        `\
 <div class="test">
 <div class="test">
 <p>xxx</p>
 </div>
 </div>
 `,
-    );
+      ],
+      [
+        `\
+::: test
+  ::: test
+  xxx
+  :::
+:::
+`,
+        `\
+<div class="test">
+<div class="test">
+<p>xxx</p>
+</div>
+</div>
+`,
+      ],
+    ];
+
+    testCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toBe(expected);
+    });
   });
 
   it("wrong syntax", () => {
-    const content = `\
+    const testCases = [
+      [
+        `\
 :::: test
 this block is closed with 5 markers below
 
@@ -115,10 +138,8 @@ auto-closed block
 
 :::::
 ::::
-`;
-
-    expect(markdownIt.render(content)).toBe(
-      `\
+`,
+        `\
 <div class="test">
 <p>this block is closed with 5 markers below</p>
 <div class="test">
@@ -127,10 +148,41 @@ auto-closed block
 </div>
 <p>::::</p>
 `,
-    );
+      ],
+      [
+        `\
+:::: test
+content
+:::
+::::
+`,
+        `\
+<div class="test">
+<p>content
+:::</p>
+</div>
+`,
+      ],
+      [
+        `\
+::: test
+::
+:::
+`,
+        `\
+<div class="test">
+<p>::</p>
+</div>
+`,
+      ],
+    ];
+
+    testCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toBe(expected);
+    });
   });
 
-  it("ending markers must be the same indent", () => {
+  it("ending markers can contain extra indent max to 3", () => {
     const testCases = [
       [
         `\
@@ -141,9 +193,9 @@ content
 `,
         `\
 <div class="test">
-<p>content
-:::</p>
+<p>content</p>
 </div>
+<p>:::</p>
 `,
       ],
       [
@@ -155,9 +207,9 @@ content
 `,
         `\
 <div class="test">
-<p>content
-:::</p>
+<p>content</p>
 </div>
+<p>:::</p>
 `,
       ],
       [
@@ -169,9 +221,9 @@ content
 `,
         `\
 <div class="test">
-<p>content
-:::</p>
+<p>content</p>
 </div>
+<p>:::</p>
 `,
       ],
       [
@@ -183,9 +235,9 @@ content
 `,
         `\
 <div class="test">
-<p>content
-:::</p>
+<p>content</p>
 </div>
+<p>:::</p>
 `,
       ],
       [
@@ -223,6 +275,91 @@ content
 </div>
 </li>
 </ul>
+`,
+      ],
+    ];
+
+    testCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toBe(expected);
+    });
+  });
+
+  it("indent shall be calculated with the parent block", () => {
+    const testCases = [
+      [
+        `\
+  ::: test
+   not a code block
+
+    code block
+  :::
+`,
+        `\
+<div class="test">
+<p>not a code block</p>
+<pre><code>code block
+</code></pre>
+</div>
+`,
+      ],
+      [
+        `\
+  ::: test
+      code
+  :::
+`,
+        `\
+<div class="test">
+<pre><code>  code
+</code></pre>
+</div>
+`,
+      ],
+    ];
+
+    testCases.forEach(([content, expected]) => {
+      expect(markdownIt.render(content)).toBe(expected);
+    });
+  });
+
+  it("content can be less indented than the opening marker", () => {
+    const testCases = [
+      [
+        `\
+  ::: test
+content
+  :::
+`,
+        `\
+<div class="test">
+<p>content</p>
+</div>
+`,
+      ],
+      [
+        `\
+  ::: test
+content
+:::
+`,
+        `\
+<div class="test">
+<p>content</p>
+</div>
+`,
+      ],
+      [
+        `\
+ ::: test
+ content
+text
+ :::
+`,
+        `\
+<div class="test">
+<p>content
+text</p>
+</div>
 `,
       ],
     ];
@@ -501,30 +638,38 @@ content
     const testCases = [
       [
         `\
- ::: test
- content
+- ::: test
+  content
 text
 `,
 
         `\
+<ul>
+<li>
 <div class="test">
 <p>content</p>
 </div>
+</li>
+</ul>
 <p>text</p>
 `,
       ],
       [
         `\
- ::: test
- content
+- ::: test
+  content
 text
- :::
+:::
 `,
 
         `\
+<ul>
+<li>
 <div class="test">
 <p>content</p>
 </div>
+</li>
+</ul>
 <p>text
 :::</p>
 `,

--- a/packages/plugin-container/src/plugin.ts
+++ b/packages/plugin-container/src/plugin.ts
@@ -57,11 +57,8 @@ export const container: PluginWithOptions<MarkdownItContainerOptions> = (md, opt
     let pos = currentLineStart + 1;
 
     // Check out the rest of the marker string
-    while (pos <= currentLineMax) {
+    for (; pos <= currentLineMax; pos++)
       if (marker[(pos - currentLineStart) % markerLength] !== state.src[pos]) break;
-
-      pos++;
-    }
 
     const markerCount = Math.floor((pos - currentLineStart) / markerLength);
 
@@ -79,6 +76,7 @@ export const container: PluginWithOptions<MarkdownItContainerOptions> = (md, opt
 
     let nextLine = startLine + 1;
     let autoClosed = false;
+    let nestedCount = 0;
 
     // Search for the end of the block
     for (
@@ -92,50 +90,56 @@ export const container: PluginWithOptions<MarkdownItContainerOptions> = (md, opt
       const nextLineStart = state.bMarks[nextLine] + state.tShift[nextLine];
       const nextLineMax = state.eMarks[nextLine];
 
-      if (nextLineStart < nextLineMax && state.sCount[nextLine] < currentLineIndent) {
+      if (nextLineStart < nextLineMax && state.sCount[nextLine] < state.blkIndent) {
         // non-empty line with negative indent should stop the list:
         // - :::
         //  test
         break;
       }
 
-      if (
-        // closing fence should be indented same as opening one
-        state.sCount[nextLine] === currentLineIndent &&
-        // match start
-        markerStart === state.src[nextLineStart]
-      ) {
-        // check rest of marker
-        for (pos = nextLineStart + 1; pos <= nextLineMax; pos++)
-          if (marker[(pos - nextLineStart) % markerLength] !== state.src[pos]) break;
+      if (markerStart !== state.src[nextLineStart]) continue;
 
-        // closing code fence must be at least as long as the opening one
-        if (Math.floor((pos - nextLineStart) / markerLength) >= markerCount) {
-          // make sure tail has spaces only
-          pos -= (pos - nextLineStart) % markerLength;
-          pos = state.skipSpaces(pos);
+      // closing fence should be indented less than 4 spaces
+      if (state.sCount[nextLine] - state.blkIndent >= 4) continue;
 
-          if (pos >= nextLineMax) {
-            // found!
-            autoClosed = true;
-            break;
-          }
-        }
+      // check rest of marker
+      for (pos = nextLineStart + 1; pos <= nextLineMax; pos++)
+        if (marker[(pos - nextLineStart) % markerLength] !== state.src[pos]) break;
+
+      const nextMarkerCount = Math.floor((pos - nextLineStart) / markerLength);
+      if (nextMarkerCount < MIN_MARKER_NUM) continue;
+
+      pos -= (pos - nextLineStart) % markerLength;
+
+      if (state.skipSpaces(pos) < nextLineMax) {
+        // marker with params opens a nested container instead of closing this one
+        if (validate(state.src.slice(pos, nextLineMax), marker.repeat(nextMarkerCount)))
+          nestedCount++;
+        continue;
       }
+
+      if (
+        // closing code fence must be at least as long as the opening one
+        nextMarkerCount >= markerCount &&
+        // a closer with a different indent can only close this container when no nested one claims it
+        (state.sCount[nextLine] === currentLineIndent || !nestedCount)
+      ) {
+        // found!
+        autoClosed = true;
+        break;
+      }
+
+      if (nestedCount) nestedCount--;
     }
 
     const oldParent = state.parentType;
     const oldLineMax = state.lineMax;
-    const oldBlkIndent = state.blkIndent;
 
     // @ts-expect-error: We are creating a new type called "container"
     state.parentType = "container";
 
     // this will prevent lazy continuations from ever going past our end marker
     state.lineMax = nextLine;
-
-    // this will update the block indent
-    state.blkIndent = currentLineIndent;
 
     const openToken = state.push(`container_${name}_open`, "div", 1);
 
@@ -153,7 +157,6 @@ export const container: PluginWithOptions<MarkdownItContainerOptions> = (md, opt
 
     state.parentType = oldParent;
     state.lineMax = oldLineMax;
-    state.blkIndent = oldBlkIndent;
     state.line = nextLine + (autoClosed ? 1 : 0);
 
     return true;


### PR DESCRIPTION
### Rationale

The strict-indent rebuild (1c59e986) introduced two regressions relative to `markdown-it-container@4.0.0` that break inputs the original plugin renders cleanly:

1. A closing marker indented 1–3 spaces relative to the opener no longer closes the container. The closer is swallowed as paragraph content and a literal `:::` leaks into the output. Upstream follows the fenced-code convention (closers tolerate up to 3 spaces of indent), and slightly indented closers are common in real documents, so migrating users hit visible stray `:::` text.
2. With an indented opener (`  ::: name`) and content at a smaller indent, the container terminates at the first content line, emitting an empty `<div>` plus leaked content and a stray `:::` paragraph. Upstream compares content lines against `blkIndent`, not the opener indent, and renders the container normally.

This PR restores upstream behavior for both while keeping the improvement the rebuild bought: an indented nested container no longer steals the outer closer (that case still renders as cleanly nested divs, and is now pinned by a test).

### Repro

Config (same for all cases):

```js
import MarkdownIt from "markdown-it";
import { container } from "@mdit/plugin-container";

const md = MarkdownIt({ linkify: true }).use(container, { name: "name" });
// upstream reference: MarkdownIt({ linkify: true }).use(require("markdown-it-container"), "name")
```

**1. Indented closer**

```markdown
::: name
content
 :::
```

Current `@mdit/plugin-container` output (same at 2 and 3 spaces):

```html
<div class="name">
<p>content
:::</p>
</div>
```

markdown-it@14.3.0 + markdown-it-container@4.0.0 output, and fixed output:

```html
<div class="name">
<p>content</p>
</div>
```

**2. Indented opener with less indented content**

```markdown
  ::: name
content
  :::
```

Current `@mdit/plugin-container` output:

```html
<div class="name"></div>
<p>content
:::</p>
```

markdown-it@14.3.0 + markdown-it-container@4.0.0 output, and fixed output:

```html
<div class="name">
<p>content</p>
</div>
```

**Preserved: indented nested container**

```markdown
::: name
  ::: name
  xxx
  :::
:::
```

Output stays the intentional improvement (upstream mis-nests here and emits a stray `<p>:::</p>` after the divs):

```html
<div class="name">
<div class="name">
<p>xxx</p>
</div>
</div>
```

### Root cause

`packages/plugin-container/src/plugin.ts` — the end-marker scan requires `state.sCount[nextLine] === currentLineIndent` exactly and treats any line indented less than the opener as terminating the container, while upstream measures both checks against `state.blkIndent` (closers accepted below `blkIndent + 4`). The rule also raised `state.blkIndent` to the opener indent, which makes less indented content unrepresentable inside the container.

### Fix

The scan now mirrors upstream: non-empty lines only terminate the container below `blkIndent`, and closer candidates are accepted below `blkIndent + 4`. To keep the nested-container improvement, the scan counts marker lines whose params pass `validate` as nested openers; a closer whose indent differs from the opener's is skipped while such a nested container is open to claim it (a closer at exactly the opener indent still closes immediately, preserving the existing "wrong syntax" semantics). The `state.blkIndent` override is dropped, so content indent is again measured from the surrounding block as upstream does — that part restores upstream's indented-code threshold and code-content indent inside indented containers, and is open to discussion if anchoring content at the opener is preferred for other reasons (it cannot be kept as-is, since it swallows any content line less indented than the opener).

Re-running the audit's 77-case upstream diff corpus against this build leaves exactly one intentional divergence: the indented nested container case above.

Updated test expectations that pinned the regressed behavior: `ending markers must be the same indent` is back to upstream semantics as `ending markers can contain extra indent max to 3`, and the `negative indent should terminate container` cases now use genuinely negative indent (list-wrapped) since a column-0 line no longer terminates a top-level indented container. The pre-rebuild `indent shall be calculated with the parent block` test is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
