### PR TITLE
docs: fix copy-paste errors and add missing docs links in package READMEs

### DIFF
--- a/packages/helper/README.md
+++ b/packages/helper/README.md
@@ -1,18 +1,16 @@
-# @mdit/plugin-helper
+# @mdit/helper
 
-[![Version](https://img.shields.io/npm/v/@mdit/plugin-helper.svg?style=flat-square&logo=npm) ![Downloads](https://img.shields.io/npm/dm/@mdit/plugin-helper.svg?style=flat-square&logo=npm) ![Size](https://img.shields.io/bundlephobia/min/@mdit/plugin-helper?style=flat-square&logo=npm)](https://www.npmjs.com/package/@mdit/plugin-helper)
+[![Version](https://img.shields.io/npm/v/@mdit/helper.svg?style=flat-square&logo=npm) ![Downloads](https://img.shields.io/npm/dm/@mdit/helper.svg?style=flat-square&logo=npm) ![Size](https://img.shields.io/bundlephobia/min/@mdit/helper?style=flat-square&logo=npm)](https://www.npmjs.com/package/@mdit/helper)
 
-Image lazyload plugin for MarkdownIt.
-
-## [Docs](https://mdit-plugins.github.io/helper.html) | [文档](https://mdit-plugins.github.io/zh/helper.html)
+Helper functions for MarkdownIt plugins.
 
 ## Install / 安装
 
 ```bash
 # pnpm
-pnpm add -D @mdit/plugin-helper
+pnpm add -D @mdit/helper
 # npm
-npm i -D @mdit/plugin-helper
+npm i -D @mdit/helper
 # yarn
-yarn add -D @mdit/plugin-helper
+yarn add -D @mdit/helper
 ```

--- a/packages/plugin-alert/README.md
+++ b/packages/plugin-alert/README.md
@@ -4,6 +4,8 @@
 
 GFM Markdown alert plugin for MarkdownIt.
 
+## [Docs](https://mdit-plugins.github.io/alert.html) | [文档](https://mdit-plugins.github.io/zh/alert.html)
+
 ## Install / 安装
 
 ```bash

--- a/packages/plugin-anchor/README.md
+++ b/packages/plugin-anchor/README.md
@@ -4,6 +4,8 @@
 
 anchor plugin for MarkdownIt.
 
+## [Docs](https://mdit-plugins.github.io/anchor.html) | [文档](https://mdit-plugins.github.io/zh/anchor.html)
+
 ## Install / 安装
 
 ```bash

--- a/packages/plugin-demo/README.md
+++ b/packages/plugin-demo/README.md
@@ -4,6 +4,8 @@
 
 demo plugin for MarkdownIt.
 
+## [Docs](https://mdit-plugins.github.io/demo.html) | [文档](https://mdit-plugins.github.io/zh/demo.html)
+
 ## Install / 安装
 
 ```bash

--- a/packages/plugin-dl/README.md
+++ b/packages/plugin-dl/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@mdit/plugin-dl.svg?style=flat-square&logo=npm) ![Downloads](https://img.shields.io/npm/dm/@mdit/plugin-dl.svg?style=flat-square&logo=npm) ![Size](https://img.shields.io/bundlephobia/min/@mdit/plugin-dl?style=flat-square&logo=npm)](https://www.npmjs.com/package/@mdit/plugin-dl)
 
-Mark plugin for MarkdownIt.
+Definition list plugin for MarkdownIt.
 
 ## [Docs](https://mdit-plugins.github.io/dl.html) | [文档](https://mdit-plugins.github.io/zh/dl.html)
 

--- a/packages/plugin-embed/README.md
+++ b/packages/plugin-embed/README.md
@@ -4,6 +4,8 @@
 
 embed plugin for MarkdownIt.
 
+## [Docs](https://mdit-plugins.github.io/embed.html) | [文档](https://mdit-plugins.github.io/zh/embed.html)
+
 ## Install / 安装
 
 ```bash

--- a/packages/plugin-icon/README.md
+++ b/packages/plugin-icon/README.md
@@ -4,6 +4,8 @@
 
 icon plugin for MarkdownIt.
 
+## [Docs](https://mdit-plugins.github.io/icon.html) | [文档](https://mdit-plugins.github.io/zh/icon.html)
+
 ## Install / 安装
 
 ```bash

--- a/packages/plugin-include/README.md
+++ b/packages/plugin-include/README.md
@@ -4,7 +4,7 @@
 
 Include plugin for MarkdownIt.
 
-This package can only run in Node.js environment. ß
+This package can only run in Node.js environment.
 
 ## [Docs](https://mdit-plugins.github.io/include.html) | [文档](https://mdit-plugins.github.io/zh/include.html)
 

--- a/packages/plugin-inline-rule/README.md
+++ b/packages/plugin-inline-rule/README.md
@@ -4,6 +4,8 @@
 
 inline-rule plugin for MarkdownIt.
 
+## [Docs](https://mdit-plugins.github.io/inline-rule.html) | [文档](https://mdit-plugins.github.io/zh/inline-rule.html)
+
 ## Install / 安装
 
 ```bash

--- a/packages/plugin-ins/README.md
+++ b/packages/plugin-ins/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@mdit/plugin-ins.svg?style=flat-square&logo=npm) ![Downloads](https://img.shields.io/npm/dm/@mdit/plugin-ins.svg?style=flat-square&logo=npm) ![Size](https://img.shields.io/bundlephobia/min/@mdit/plugin-ins?style=flat-square&logo=npm)](https://www.npmjs.com/package/@mdit/plugin-ins)
 
-Mark plugin for MarkdownIt.
+Insert plugin for MarkdownIt.
 
 ## [Docs](https://mdit-plugins.github.io/ins.html) | [文档](https://mdit-plugins.github.io/zh/ins.html)
 

--- a/packages/plugin-plantuml/README.md
+++ b/packages/plugin-plantuml/README.md
@@ -4,6 +4,8 @@
 
 plantuml plugin for MarkdownIt.
 
+## [Docs](https://mdit-plugins.github.io/plantuml.html) | [文档](https://mdit-plugins.github.io/zh/plantuml.html)
+
 ## Install / 安装
 
 ```bash

--- a/packages/plugin-ruby/README.md
+++ b/packages/plugin-ruby/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@mdit/plugin-ruby.svg?style=flat-square&logo=npm) ![Downloads](https://img.shields.io/npm/dm/@mdit/plugin-ruby.svg?style=flat-square&logo=npm) ![Size](https://img.shields.io/bundlephobia/min/@mdit/plugin-ruby?style=flat-square&logo=npm)](https://www.npmjs.com/package/@mdit/plugin-ruby)
 
-Mark plugin for MarkdownIt.
+Ruby plugin for MarkdownIt.
 
 ## [Docs](https://mdit-plugins.github.io/ruby.html) | [文档](https://mdit-plugins.github.io/zh/ruby.html)
 

--- a/packages/plugin-spoiler/README.md
+++ b/packages/plugin-spoiler/README.md
@@ -2,7 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/@mdit/plugin-spoiler.svg?style=flat-square&logo=npm) ![Downloads](https://img.shields.io/npm/dm/@mdit/plugin-spoiler.svg?style=flat-square&logo=npm) ![Size](https://img.shields.io/bundlephobia/min/@mdit/plugin-spoiler?style=flat-square&logo=npm)](https://www.npmjs.com/package/@mdit/plugin-spoiler)
 
-Mark plugin for MarkdownIt.
+Spoiler plugin for MarkdownIt.
 
 ## [Docs](https://mdit-plugins.github.io/spoiler.html) | [文档](https://mdit-plugins.github.io/zh/spoiler.html)
 


### PR DESCRIPTION
An audit of all 38 package READMEs against each package's actual purpose (package.json, src exports, docs pages) found six files with copy-paste leftovers from sibling packages, plus seven READMEs that never link their existing docs pages. README-only, no behavior changes.

## Copy-paste fixes

### `packages/helper/README.md`

Copied from `plugin-img-lazyload` and adapted to a package name that doesn't exist:

- title, badges, npm link, and install commands all referenced `@mdit/plugin-helper` → now `@mdit/helper`
- tagline said "Image lazyload plugin for MarkdownIt." → now "Helper functions for MarkdownIt plugins." (matches package.json)
- removed the Docs row: it linked to `mdit-plugins.github.io/helper.html`, which has no corresponding page (`docs/src/helper.md` doesn't exist)

### Tagline fixes (verbatim copies of plugin-mark's line 5)

| Package | Before | After |
| --- | --- | --- |
| `plugin-dl` | Mark plugin for MarkdownIt. | Definition list plugin for MarkdownIt. |
| `plugin-ins` | Mark plugin for MarkdownIt. | Insert plugin for MarkdownIt. |
| `plugin-ruby` | Mark plugin for MarkdownIt. | Ruby plugin for MarkdownIt. |
| `plugin-spoiler` | Mark plugin for MarkdownIt. | Spoiler plugin for MarkdownIt. |

### `packages/plugin-include/README.md`

Removed a stray `ß` at the end of "This package can only run in Node.js environment." (the same sentence appears without it in katex-slim, mathjax-slim, and snippet).

## Missing docs links added

These packages have published docs pages (both en and zh exist under `docs/src/`) but their READMEs never linked them. Added the standard `## [Docs](…) | [文档](…)` row between the tagline and the Install section, matching the sibling template:

`plugin-alert`, `plugin-anchor`, `plugin-demo`, `plugin-embed`, `plugin-icon`, `plugin-inline-rule`, `plugin-plantuml`

The remaining READMEs were verified clean (titles, badges, docs links, install commands, and code samples all reference the right package). `plugin-katex-slim` / `plugin-mathjax-slim` intentionally keep linking to `katex.html` / `mathjax.html` since no `-slim` docs pages exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)