### PR TITLE
docs: fix wrong-plugin copy-paste leftovers

### DIFF
--- a/docs/src/alert.md
+++ b/docs/src/alert.md
@@ -46,7 +46,6 @@ The `ALERT_NAME` isn't case sensitive and can be the following string:
 
   ```js
   md.use(alert, {
-    name: "warning",
     deep: true,
   });
   ```

--- a/docs/src/field.md
+++ b/docs/src/field.md
@@ -203,11 +203,39 @@ interface FieldAttr {
 
 ### fieldsOpenRender
 
+- Type: `RenderRule`
+
+<!-- @include: ./render-rule.snippet.md -->
+
+- Details: Fields container open render.
+
+### fieldsCloseRender
+
+- Type: `RenderRule`
+
+<!-- @include: ./render-rule.snippet.md -->
+
+- Details: Fields container close render.
+
+### fieldOpenRender
+
 - Type: `MarkdownItFieldOpenRender`
 
 ```ts
 interface FieldAttrInfo {
+  /**
+   * attribute name
+   */
+  attr: string;
+
+  /**
+   * attribute display name
+   */
   name: string;
+
+  /**
+   * attribute value
+   */
   value: string | true;
 }
 
@@ -218,12 +246,12 @@ interface FieldMeta {
   name: string;
 
   /**
-   * field level, starting from 0
+   * field level, starting from 1
    */
   level: number;
 
   /**
-   * sorted field attributes, key is attribute name, value is attribute value.
+   * sorted field attributes
    */
   attributes: FieldAttrInfo[];
 }
@@ -240,22 +268,6 @@ type MarkdownItFieldOpenRender = (
   self: Renderer,
 ) => string;
 ```
-
-- Details: Fields container open render.
-
-### fieldsCloseRender
-
-- Type: `RenderRule`
-
-<!-- @include: ./render-rule.snippet.md -->
-
-- Details: Fields container close render.
-
-### fieldOpenRender
-
-- Type: `RenderRule`
-
-<!-- @include: ./render-rule.snippet.md -->
 
 - Details: Field item open render.
 

--- a/docs/src/img-size.md
+++ b/docs/src/img-size.md
@@ -63,7 +63,7 @@ Both `width` and `height` should be numbers as pixels and are required. Setting 
 Renders as ↓
 
 ```html
-<img src="/example.png" alt="Alt" width="200" height="300" />
+<img src="/example.png" alt="Alt" width="200" height="200" />
 <img src="/example.jpg" alt="Alt" width="200" />
 <img src="/example.bmp" alt="Alt" height="300" />
 ```

--- a/docs/src/snippet.md
+++ b/docs/src/snippet.md
@@ -62,7 +62,7 @@ E.g.:
 - `<<< example.html` import `example.html` as snippet
 - `<<< example.js{1,3,7-9}`. import `example.js` as snippet and highlight lines 1, 3, 7 to 9
 - `<<< example.css#normalize` import region `normalize` in `example.css`
-- `<<< example.ts#plugin{2-5}` import region `plugin` in `example.ts` and highlight lines 1 to 3
+- `<<< example.ts#plugin{2-5}` import region `plugin` in `example.ts` and highlight lines 2 to 5
 
 ::: note
 
@@ -138,7 +138,7 @@ const mdIt = MarkdownIt().use(snippet, {
 });
 // #endregion snippet
 
-mdIt.render("@snippet(./path/to/snippet/file.md)", {
+mdIt.render("<<< ./path/to/snippet/file.md", {
   filePath: "path/to/current/file.md",
 });
 ```
@@ -156,7 +156,7 @@ const mdIt = MarkdownIt().use(snippet, {
 });
 // #endregion snippet
 
-mdIt.render("@snippet(./path/to/snippet/file.md)", {
+mdIt.render("<<< ./path/to/snippet/file.md", {
   filePath: "path/to/current/file.md",
 });
 ```

--- a/docs/src/tex.md
+++ b/docs/src/tex.md
@@ -19,9 +19,9 @@ If you are looking for an out of box solution, you should try [@mdit/plugin-kate
 
 ```ts
 import MarkdownIt from "markdown-it";
-import { figure } from "@mdit/plugin-figure";
+import { tex } from "@mdit/plugin-tex";
 
-const mdIt = MarkdownIt().use(figure, {
+const mdIt = MarkdownIt().use(tex, {
   render: (content, displayMode) => {
     // render tex here and return
   },

--- a/docs/src/zh/README.md
+++ b/docs/src/zh/README.md
@@ -66,7 +66,7 @@ features:
 
   - title: footnote
     icon: quote-left
-    details: 支持页脚
+    details: 支持脚注
     link: ./footnote.html
 
   - title: icon
@@ -151,12 +151,12 @@ features:
 
   - title: sub
     icon: subscript
-    details: 支持上角标
+    details: 支持下角标
     link: ./sub.html
 
   - title: sup
     icon: superscript
-    details: 支持下角标
+    details: 支持上角标
     link: ./sup.html
 
   - title: tab

--- a/docs/src/zh/alert.md
+++ b/docs/src/zh/alert.md
@@ -46,7 +46,6 @@ mdIt.render(`
 
   ```js
   md.use(alert, {
-    name: "warning",
     deep: true,
   });
   ```

--- a/docs/src/zh/field.md
+++ b/docs/src/zh/field.md
@@ -191,11 +191,39 @@ interface FieldAttr {
 
 ### fieldsOpenRender
 
+- 类型：`RenderRule`
+
+<!-- @include: ../render-rule.snippet.md -->
+
+- 详情：字段容器打开渲染函数。
+
+### fieldsCloseRender
+
+- 类型：`RenderRule`
+
+<!-- @include: ../render-rule.snippet.md -->
+
+- 详情：字段容器关闭渲染函数。
+
+### fieldOpenRender
+
 - 类型：`MarkdownItFieldOpenRender`
 
 ```ts
 interface FieldAttrInfo {
+  /**
+   * 属性名
+   */
+  attr: string;
+
+  /**
+   * 属性显示名称
+   */
   name: string;
+
+  /**
+   * 属性值
+   */
   value: string | true;
 }
 
@@ -206,12 +234,12 @@ interface FieldMeta {
   name: string;
 
   /**
-   * 字段级别，从 0 开始
+   * 字段级别，从 1 开始
    */
   level: number;
 
   /**
-   * 排序后的字段属性，键为属性名，值为属性值。
+   * 排序后的字段属性
    */
   attributes: FieldAttrInfo[];
 }
@@ -228,22 +256,6 @@ type MarkdownItFieldOpenRender = (
   self: Renderer,
 ) => string;
 ```
-
-- 详情：字段容器打开渲染函数。
-
-### fieldsCloseRender
-
-- 类型：`RenderRule`
-
-<!-- @include: ../render-rule.snippet.md -->
-
-- 详情：字段容器关闭渲染函数。
-
-### fieldOpenRender
-
-- 类型：`RenderRule`
-
-<!-- @include: ../render-rule.snippet.md -->
 
 - 详情：字段项打开渲染函数。
 

--- a/docs/src/zh/img-size.md
+++ b/docs/src/zh/img-size.md
@@ -63,7 +63,7 @@ mdLegacy.render("![image](https://example.com/image.png =300x200)");
 渲染为 ↓
 
 ```html
-<img src="/example.png" alt="替代文字" width="200" height="300" />
+<img src="/example.png" alt="替代文字" width="200" height="200" />
 <img src="/example.jpg" alt="替代文字" width="200" />
 <img src="/example.bmp" alt="替代文字" height="300" />
 ```

--- a/docs/src/zh/snippet.md
+++ b/docs/src/zh/snippet.md
@@ -62,7 +62,7 @@ mdIt.use(snippet, {
 - `<<< example.html` 导入 `example.html` 作为片段
 - `<<< example.js{1,3,7-9}`。 将 `example.js` 作为代码段导入并突出显示第 1、3、7 到 9 行
 - `<<< example.css#normalize` 在 `example.css` 中导入 `normalize` 片段
-- `<<< example.ts#plugin{2-5}` 在 `example.ts` 中导入 `plugin` 片段并突出显示第 1 到 3 行
+- `<<< example.ts#plugin{2-5}` 在 `example.ts` 中导入 `plugin` 片段并突出显示第 2 到 5 行
 
 ::: note
 
@@ -138,7 +138,7 @@ const mdIt = MarkdownIt().use(snippet, {
 });
 // #endregion snippet
 
-mdIt.render("@snippet(./path/to/snippet/file.md)", {
+mdIt.render("<<< ./path/to/snippet/file.md", {
   filePath: "path/to/current/file.md",
 });
 ```
@@ -156,7 +156,7 @@ const mdIt = MarkdownIt().use(snippet, {
 });
 // #endregion snippet
 
-mdIt.render("@snippet(./path/to/snippet/file.md)", {
+mdIt.render("<<< ./path/to/snippet/file.md", {
   filePath: "path/to/current/file.md",
 });
 ```

--- a/docs/src/zh/sub.md
+++ b/docs/src/zh/sub.md
@@ -3,7 +3,7 @@ title: "@mdit/plugin-sub"
 icon: subscript
 ---
 
-提供上角标支持的插件。
+提供下角标支持的插件。
 
 <!-- more -->
 
@@ -20,7 +20,7 @@ mdIt.render("H~2~O");
 
 ## 格式
 
-使用 `~ ~` 进行上角标标注。
+使用 `~ ~` 进行下角标标注。
 
 ::: tip 转义
 

--- a/docs/src/zh/sup.md
+++ b/docs/src/zh/sup.md
@@ -3,7 +3,7 @@ title: "@mdit/plugin-sup"
 icon: superscript
 ---
 
-提供下角标支持的插件。
+提供上角标支持的插件。
 
 <!-- more -->
 
@@ -20,7 +20,7 @@ mdIt.render("19^th^");
 
 ## 格式
 
-使用 `^ ^` 进行下角标标注。
+使用 `^ ^` 进行上角标标注。
 
 ::: tip 转义
 

--- a/docs/src/zh/tex.md
+++ b/docs/src/zh/tex.md
@@ -17,9 +17,9 @@ icon: square-root-variable
 
 ```ts
 import MarkdownIt from "markdown-it";
-import { figure } from "@mdit/plugin-figure";
+import { tex } from "@mdit/plugin-tex";
 
-const mdIt = MarkdownIt().use(figure, {
+const mdIt = MarkdownIt().use(tex, {
   render: (content, displayMode) => {
     // 在此渲染 tex 并返回
   },


### PR DESCRIPTION
Part 1 of a 5-PR split from a full docs audit (en+zh) — this PR fixes content copied from a different plugin's page.

- `docs/src/tex.md`, `docs/src/zh/tex.md` — Usage block was copied from `figure.md`; now imports and uses `tex` from `@mdit/plugin-tex`.
- `docs/src/zh/sub.md` — described 上角标 (superscript); corrected to 下角标 (subscript) in both the intro and the syntax line.
- `docs/src/zh/sup.md` — described 下角标 (subscript); corrected to 上角标 (superscript) in both the intro and the syntax line.
- `docs/src/zh/README.md` — feature list: `sub`/`sup` descriptions were swapped, and `footnote` said 支持页脚 (page footer) instead of 支持脚注 (footnotes).
- `docs/src/alert.md`, `docs/src/zh/alert.md` — the `deep: true` example passed `name: "warning"`, which is not an option of this plugin (see `packages/plugin-alert/src/options.ts`: `alertNames` / `deep` / `openRender` / `closeRender` / `titleRender`).
- `docs/src/snippet.md`, `docs/src/zh/snippet.md` — two `mdIt.render()` examples used a non-existent `@snippet(...)` syntax; the plugin only implements `<<<` (see `packages/plugin-snippet/src/plugin.ts`).
- `docs/src/snippet.md`, `docs/src/zh/snippet.md` — the `{2-5}` example claimed it highlights lines 1 to 3; now says 2 to 5.
- `docs/src/img-size.md`, `docs/src/zh/img-size.md` — Obsidian syntax "Renders as" table: input `![Alt|200x200](/example.png)` rendered `height="300"`; now `height="200"`.
- `docs/src/field.md`, `docs/src/zh/field.md` — `fieldsOpenRender` and `fieldOpenRender` had their types swapped versus `packages/plugin-field/src/options.ts` (`fieldsOpenRender?: RenderRule`, `fieldOpenRender?: MarkdownItFieldOpenRender`). Swapped the types, moved the `FieldToken`/`FieldMeta`/`FieldAttrInfo`/`MarkdownItFieldOpenRender` interface block to `fieldOpenRender` (only `${name}_field_open` tokens carry `meta`), and corrected that block to match the source: added the missing `attr` field to `FieldAttrInfo`, fixed `level` to start from 1, and fixed the `attributes` comment (it is a sorted array, not a key/value map).

Sibling PRs edit some of the same files (tex.md, field.md, snippet.md, img-size.md) — expect trivial merge conflicts; merge in any order and rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
