### PR TITLE
docs: fix examples that do not render as shown

### DIFF
--- a/docs/src/abbr.md
+++ b/docs/src/abbr.md
@@ -59,7 +59,7 @@ will be
 *[HTML]: Hyper Text Markup Language
 *[W3C]: World Wide Web Consortium
 
-The HTML specificationis maintained by the W3C.
+The HTML specification is maintained by the W3C.
 
 :::
 

--- a/docs/src/anchor.md
+++ b/docs/src/anchor.md
@@ -191,7 +191,7 @@ Unlike the other presets, `linkAfterHeader` has no default options — pass at l
 ```ts
 import { anchor, linkAfterHeader } from "@mdit/plugin-anchor";
 
-md.use(anchor, {
+mdIt.use(anchor, {
   permalink: linkAfterHeader({
     assistiveText: (title) => `Permalink for ${title}`,
     visuallyHiddenClass: "sr-only",

--- a/docs/src/anchor.md
+++ b/docs/src/anchor.md
@@ -189,9 +189,10 @@ flexibility for accessible screen reader experiences.
 Unlike the other presets, `linkAfterHeader` has no default options — pass at least `assistiveText` and `visuallyHiddenClass` when using the default `visually-hidden` style:
 
 ```ts
+import MarkdownIt from "markdown-it";
 import { anchor, linkAfterHeader } from "@mdit/plugin-anchor";
 
-mdIt.use(anchor, {
+const mdIt = MarkdownIt().use(anchor, {
   permalink: linkAfterHeader({
     assistiveText: (title) => `Permalink for ${title}`,
     visuallyHiddenClass: "sr-only",

--- a/docs/src/anchor.md
+++ b/docs/src/anchor.md
@@ -139,7 +139,7 @@ include links inside headings.
 import { headerLink } from "@mdit/plugin-anchor";
 ```
 
-**Output:** `<h2 id="title"><a href="#title">Title</a></h2>`
+**Output:** `<h2 id="title" tabindex="-1"><a class="header-anchor" href="#title">Title</a></h2>`
 
 | Name              | Description                                                             | Default |
 | ----------------- | ----------------------------------------------------------------------- | ------- |
@@ -154,7 +154,7 @@ Inserts a permalink anchor inside the heading, after or before the text.
 import { linkInsideHeader } from "@mdit/plugin-anchor";
 ```
 
-**Output:** `<h2 id="title">Title <a href="#title">#</a></h2>`
+**Output:** `<h2 id="title" tabindex="-1">Title <a class="header-anchor" href="#title">#</a></h2>`
 
 | Name         | Description                                                                                                | Default |
 | ------------ | ---------------------------------------------------------------------------------------------------------- | ------- |
@@ -179,18 +179,27 @@ Alias for `linkInsideHeader` with `ariaHidden: true` by default.
 import { ariaHidden } from "@mdit/plugin-anchor";
 ```
 
-**Output:** `<h2 id="title">Title <a href="#title" aria-hidden="true">#</a></h2>`
+**Output:** `<h2 id="title" tabindex="-1">Title <a class="header-anchor" href="#title" aria-hidden="true">#</a></h2>`
 
 ### linkAfterHeader
 
 Places a permalink anchor **after** the heading block. Offers the most
 flexibility for accessible screen reader experiences.
 
+Unlike the other presets, `linkAfterHeader` has no default options — pass at least `assistiveText` and `visuallyHiddenClass` when using the default `visually-hidden` style:
+
 ```ts
-import { linkAfterHeader } from "@mdit/plugin-anchor";
+import { anchor, linkAfterHeader } from "@mdit/plugin-anchor";
+
+md.use(anchor, {
+  permalink: linkAfterHeader({
+    assistiveText: (title) => `Permalink for ${title}`,
+    visuallyHiddenClass: "sr-only",
+  }),
+});
 ```
 
-**Output:** `<h2 id="title">Title</h2><a href="#title"><span class="sr-only">Permalink</span> <span aria-hidden="true">#</span></a>`
+**Output:** `<h2 id="title" tabindex="-1">Title</h2><a class="header-anchor" href="#title"><span class="sr-only">Permalink for Title</span> <span aria-hidden="true">#</span></a>`
 
 | Name                  | Description                                                                                              | Default           |
 | --------------------- | -------------------------------------------------------------------------------------------------------- | ----------------- |

--- a/docs/src/embed.md
+++ b/docs/src/embed.md
@@ -147,8 +147,8 @@ interface EmbedConfig {
 }
 ```
 
-- Default: `[]`
-- Details: An array of embed configurations.
+- Required: Yes
+- Details: An array of embed configurations. The plugin throws if it is missing or not an array.
 
 Each configuration must have:
 

--- a/docs/src/embed.md
+++ b/docs/src/embed.md
@@ -147,8 +147,8 @@ interface EmbedConfig {
 }
 ```
 
-- Required: Yes
-- Details: An array of embed configurations. The plugin throws if it is missing or not an array.
+- Default: `[]`
+- Details: An array of embed configurations.
 
 Each configuration must have:
 

--- a/docs/src/field.md
+++ b/docs/src/field.md
@@ -287,7 +287,7 @@ Description 2
 @parent@
 Parent description.
 
-@child@
+@@child@
 Child description.
 :::
 

--- a/docs/src/icon.md
+++ b/docs/src/icon.md
@@ -20,10 +20,10 @@ mdIt.render("iPhone is made by ::apple::.");
 
 ## Syntax
 
-Use `::icon classes::` to insert custom icons. By default the plugin will render a `<i>` tag with the given icon class. Any classes started with a `=` will be treated as a size definition, and `/` will be treated as a color definition:
+Use `::icon classes::` to insert custom icons. By default the plugin renders a `<i>` tag with the raw content as its class. The bundled renderers (`defaultRender`, `iconifyRender`, `fontawesomeRender` and `iconfontRender`), used via the `render` option, additionally treat any part starting with `=` as a size definition and any part starting with `/` as a color definition:
 
 ```md
-<!-- <i class="icon1" style="font-size:16px;color:red" -->
+<!-- with `render: defaultRender`: <i icon="icon1" style="font-size:16px;color:red"></i> -->
 
 ::icon1 =16 /red::
 ```

--- a/docs/src/img-size.md
+++ b/docs/src/img-size.md
@@ -15,7 +15,7 @@ import { legacyImgSize, imgSize, obsidianImgSize } from "@mdit/plugin-img-size";
 
 // New syntax
 const mdNew = MarkdownIt().use(imgSize);
-mdNew.render("![image =300x200](https://example.com/image.png =300x200)");
+mdNew.render("![image =300x200](https://example.com/image.png)");
 
 // Obsidian syntax
 const mdObsidian = MarkdownIt().use(obsidianImgSize);

--- a/docs/src/include.md
+++ b/docs/src/include.md
@@ -47,7 +47,7 @@ mdIt.use(include, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return join(cwd, path);
+    return cwd ? join(cwd, path) : path;
   },
 });
 ```

--- a/docs/src/include.md
+++ b/docs/src/include.md
@@ -34,6 +34,7 @@ Also, to support alias, you can set `resolvePath` in plugin options.
 For example, the following code add support for `@src` alias:
 
 ```ts
+import { join } from "node:path";
 import MarkdownIt from "markdown-it";
 import { include } from "@mdit/plugin-include";
 
@@ -46,7 +47,7 @@ mdIt.use(include, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return path.join(cwd, path);
+    return join(cwd, path);
   },
 });
 ```

--- a/docs/src/inline-rule.md
+++ b/docs/src/inline-rule.md
@@ -18,6 +18,7 @@ const mdIt = MarkdownIt().use(inlineRule, {
   tag: "mark",
   token: "mark",
   nested: true,
+  double: true,
   placement: "before-emphasis",
 });
 
@@ -96,6 +97,7 @@ md.use(inlineRule, {
   tag: "span",
   token: "spoiler",
   nested: true,
+  double: true,
   placement: "before-emphasis",
   attrs: [["class", "spoiler"]],
 });
@@ -124,13 +126,14 @@ md.use(inlineRule, {
 
 ```ts
 md.use(inlineRule, {
-  marker: "?",
+  marker: "%",
   tag: "span",
   token: "help",
   nested: true,
+  double: true,
   placement: "before-emphasis",
   attrs: [["class", "help-text"]],
 });
 
-// ??help text?? → <span class="help-text">help text</span>
+// %%help text%% → <span class="help-text">help text</span>
 ```

--- a/docs/src/katex.md
+++ b/docs/src/katex.md
@@ -62,7 +62,7 @@ Euler’s identity $e^{i\pi}+1=0$ is a beautiful formula in $\mathbb{R}^2$.
 
 $$
 \frac {\partial^r} {\partial \omega^r} \left(\frac {y^{\omega}} {\omega}\right)
-= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^ Ir \cdots (r-i+1) (\log y)^{ri}} {\omega^i} \right\}
+= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^i r \cdots (r-i+1) (\log y)^{r-i}} {\omega^i} \right\}
 $$
 
 :::

--- a/docs/src/mathjax.md
+++ b/docs/src/mathjax.md
@@ -143,7 +143,7 @@ Euler’s identity $e^{i\pi}+1=0$ is a beautiful formula in $\mathbb{R}^2$.
 
 $$
 \frac {\partial^r} {\partial \omega^r} \left(\frac {y^{\omega}} {\omega}\right)
-= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^ Ir \cdots (r-i+1) (\log y)^{ri}} {\omega^i} \right\}
+= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^i r \cdots (r-i+1) (\log y)^{r-i}} {\omega^i} \right\}
 $$
 
 :::

--- a/docs/src/snippet.md
+++ b/docs/src/snippet.md
@@ -47,7 +47,7 @@ mdIt.use(snippet, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return join(cwd, path);
+    return cwd ? join(cwd, path) : path;
   },
 });
 ```

--- a/docs/src/snippet.md
+++ b/docs/src/snippet.md
@@ -34,6 +34,7 @@ Also, to support alias, you can set `resolvePath` in plugin options.
 For example, the following code add support for `@src` alias:
 
 ```ts
+import { join } from "node:path";
 import MarkdownIt from "markdown-it";
 import { snippet } from "@mdit/plugin-snippet";
 
@@ -46,7 +47,7 @@ mdIt.use(snippet, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return path.join(cwd, path);
+    return join(cwd, path);
   },
 });
 ```

--- a/docs/src/sub.md
+++ b/docs/src/sub.md
@@ -39,4 +39,4 @@ Use `~ ~` to mark the subscript.
 ## Demo
 
 <!-- prettier-ignore -->
-`H~2~O`: H~~2~~O
+`H~2~O`: H~2~O

--- a/docs/src/tex.md
+++ b/docs/src/tex.md
@@ -105,6 +105,8 @@ Escaping can be done by using `\` before the `$` character, or adding space both
 - Default: `false`
 - Details: Whether to allow inline math with spaces on ends. NOT recommended to set this to true, because it will likely break the default usage of `$`.
 
+<!-- #endregion options -->
+
 ### render
 
 - Type: `TexRender`
@@ -124,8 +126,6 @@ type TexRender = (content: string, displayMode: boolean, env: MarkdownItEnv) => 
 - Required: Yes
 - Details: Tex Render function. Takes content, displayMode, and environment, returns rendered string.
 
-<!-- #endregion options -->
-
 ## Demo
 
 Euler’s identity $e^{i\pi}+1=0$ is a beautiful formula in $\mathbb{R}^2$.
@@ -136,13 +136,13 @@ Euler’s identity $e^{i\pi}+1=0$ is a beautiful formula in $\mathbb{R}^2$.
 
 $$
 \frac {\partial^r} {\partial \omega^r} \left(\frac {y^{\omega}} {\omega}\right)
-= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^ Ir \cdots (r-i+1) (\log y)^{ri}} {\omega^i} \right\}
+= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^i r \cdots (r-i+1) (\log y)^{r-i}} {\omega^i} \right\}
 $$
 
 ```md
 $$
 \frac {\partial^r} {\partial \omega^r} \left(\frac {y^{\omega}} {\omega}\right)
-= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^ Ir \cdots (r-i+1) (\log y)^{ri}} {\omega^i} \right\}
+= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^i r \cdots (r-i+1) (\log y)^{r-i}} {\omega^i} \right\}
 $$
 ```
 
@@ -154,7 +154,7 @@ $$
   - `+`: $+$
   - `-`: $-$
   - `\times`: $\times$
-  - `\ div`: $\div$
+  - `\div`: $\div$
   - `=`: $=$
   - `\pm`: $\pm$
   - `\cdot`: $\cdot$
@@ -274,7 +274,7 @@ Various parentheses are represented by commands such as `()`, `[]`, `\{\}`, `\la
 
 Note that curly braces are usually used to enter command and environment parameters, so they must be preceded by `\` in mathematical formulas.
 
-Because the application of `|` and `\|` in LaTeX is too casual, we recommend using `\lvert\rvert` and `\ lVert\rVert` instead.
+Because the application of `|` and `\|` in LaTeX is too casual, we recommend using `\lvert\rvert` and `\lVert\rVert` instead.
 
 :::
 
@@ -441,14 +441,18 @@ $$
 $$
 
 ```md
-$\tag{1} x+y^{2x}$
+$$
+\tag{1} x+y^{2x}
+$$
 
-$\tag*{1} x+y^{2x}$
+$$
+\tag*{1} x+y^{2x}
+$$
 ```
 
 ### Segmented Functions
 
-Use `case` environment
+Use `cases` environment
 
 $$
 y= \begin{cases}

--- a/docs/src/zh/abbr.md
+++ b/docs/src/zh/abbr.md
@@ -59,7 +59,7 @@ The HTML specification is maintained by the W3C.
 *[HTML]: Hyper Text Markup Language
 *[W3C]: World Wide Web Consortium
 
-The HTML specificationis maintained by the W3C.
+The HTML specification is maintained by the W3C.
 
 :::
 

--- a/docs/src/zh/anchor.md
+++ b/docs/src/zh/anchor.md
@@ -185,9 +185,10 @@ import { ariaHidden } from "@mdit/plugin-anchor";
 与其他预设不同，`linkAfterHeader` 没有默认选项 —— 使用默认的 `visually-hidden` 样式时至少需要传入 `assistiveText` 和 `visuallyHiddenClass`：
 
 ```ts
+import MarkdownIt from "markdown-it";
 import { anchor, linkAfterHeader } from "@mdit/plugin-anchor";
 
-mdIt.use(anchor, {
+const mdIt = MarkdownIt().use(anchor, {
   permalink: linkAfterHeader({
     assistiveText: (title) => `永久链接：${title}`,
     visuallyHiddenClass: "sr-only",

--- a/docs/src/zh/anchor.md
+++ b/docs/src/zh/anchor.md
@@ -137,7 +137,7 @@ Anchor 插件会复用已有的 `id`。
 import { headerLink } from "@mdit/plugin-anchor";
 ```
 
-**输出：** `<h2 id="title"><a href="#title">标题</a></h2>`
+**输出：** `<h2 id="title" tabindex="-1"><a class="header-anchor" href="#title">标题</a></h2>`
 
 | 名称              | 描述                                                     | 默认值  |
 | ----------------- | -------------------------------------------------------- | ------- |
@@ -152,7 +152,7 @@ import { headerLink } from "@mdit/plugin-anchor";
 import { linkInsideHeader } from "@mdit/plugin-anchor";
 ```
 
-**输出：** `<h2 id="title">标题 <a href="#title">#</a></h2>`
+**输出：** `<h2 id="title" tabindex="-1">标题 <a class="header-anchor" href="#title">#</a></h2>`
 
 | 名称         | 描述                                                                  | 默认值  |
 | ------------ | --------------------------------------------------------------------- | ------- |
@@ -176,17 +176,26 @@ import { linkInsideHeader } from "@mdit/plugin-anchor";
 import { ariaHidden } from "@mdit/plugin-anchor";
 ```
 
-**输出：** `<h2 id="title">标题 <a href="#title" aria-hidden="true">#</a></h2>`
+**输出：** `<h2 id="title" tabindex="-1">标题 <a class="header-anchor" href="#title" aria-hidden="true">#</a></h2>`
 
 ### linkAfterHeader
 
 在标题块**之后**放置永久链接锚点。提供最灵活的屏幕阅读器无障碍体验。
 
+与其他预设不同，`linkAfterHeader` 没有默认选项 —— 使用默认的 `visually-hidden` 样式时至少需要传入 `assistiveText` 和 `visuallyHiddenClass`：
+
 ```ts
-import { linkAfterHeader } from "@mdit/plugin-anchor";
+import { anchor, linkAfterHeader } from "@mdit/plugin-anchor";
+
+md.use(anchor, {
+  permalink: linkAfterHeader({
+    assistiveText: (title) => `永久链接：${title}`,
+    visuallyHiddenClass: "sr-only",
+  }),
+});
 ```
 
-**输出：** `<h2 id="title">标题</h2><a href="#title"><span class="sr-only">永久链接</span> <span aria-hidden="true">#</span></a>`
+**输出：** `<h2 id="title" tabindex="-1">标题</h2><a class="header-anchor" href="#title"><span class="sr-only">永久链接：标题</span> <span aria-hidden="true">#</span></a>`
 
 | 名称                  | 描述                                                                             | 默认值            |
 | --------------------- | -------------------------------------------------------------------------------- | ----------------- |

--- a/docs/src/zh/anchor.md
+++ b/docs/src/zh/anchor.md
@@ -187,7 +187,7 @@ import { ariaHidden } from "@mdit/plugin-anchor";
 ```ts
 import { anchor, linkAfterHeader } from "@mdit/plugin-anchor";
 
-md.use(anchor, {
+mdIt.use(anchor, {
   permalink: linkAfterHeader({
     assistiveText: (title) => `永久链接：${title}`,
     visuallyHiddenClass: "sr-only",

--- a/docs/src/zh/embed.md
+++ b/docs/src/zh/embed.md
@@ -124,7 +124,10 @@ const md = MarkdownIt().use(embed, {
 
 ### config
 
-- 类型：`EmbedConfig[]`
+- 类型: `EmbedConfig[]`
+- 默认值: `[]`
+
+嵌入配置数组。
 
 ```ts
 interface EmbedConfig {
@@ -148,9 +151,6 @@ interface EmbedConfig {
   allowInline?: boolean;
 }
 ```
-
-- 必填：是
-- 详情：嵌入配置数组。缺失或不是数组时插件会抛出错误。
 
 每个配置必须包含：
 

--- a/docs/src/zh/embed.md
+++ b/docs/src/zh/embed.md
@@ -125,9 +125,9 @@ const md = MarkdownIt().use(embed, {
 ### config
 
 - 类型: `EmbedConfig[]`
-- 默认值: `[]`
+- 必填: 是
 
-嵌入配置数组。
+嵌入配置数组。缺失或不是数组时插件会抛出错误。
 
 ```ts
 interface EmbedConfig {

--- a/docs/src/zh/embed.md
+++ b/docs/src/zh/embed.md
@@ -125,8 +125,6 @@ const md = MarkdownIt().use(embed, {
 ### config
 
 - 类型：`EmbedConfig[]`
-- 必填：是
-- 详情：嵌入配置数组。缺失或不是数组时插件会抛出错误。
 
 ```ts
 interface EmbedConfig {
@@ -150,6 +148,9 @@ interface EmbedConfig {
   allowInline?: boolean;
 }
 ```
+
+- 必填：是
+- 详情：嵌入配置数组。缺失或不是数组时插件会抛出错误。
 
 每个配置必须包含：
 

--- a/docs/src/zh/embed.md
+++ b/docs/src/zh/embed.md
@@ -124,10 +124,9 @@ const md = MarkdownIt().use(embed, {
 
 ### config
 
-- 类型: `EmbedConfig[]`
-- 必填: 是
-
-嵌入配置数组。缺失或不是数组时插件会抛出错误。
+- 类型：`EmbedConfig[]`
+- 必填：是
+- 详情：嵌入配置数组。缺失或不是数组时插件会抛出错误。
 
 ```ts
 interface EmbedConfig {

--- a/docs/src/zh/field.md
+++ b/docs/src/zh/field.md
@@ -275,7 +275,7 @@ type MarkdownItFieldOpenRender = (
 @parent@
 父级项目描述。
 
-@child@
+@@child@
 子级项目描述。
 :::
 

--- a/docs/src/zh/footnote.md
+++ b/docs/src/zh/footnote.md
@@ -33,8 +33,8 @@ mdIt.render("Inline footnote^[Text of inline footnote] definition.");
   ```MD
   脚注 1 链接 [^first]。
 
-  [^first]：脚注可以参考[^second]。
-  [^second]：其他脚注。
+  [^first]: 脚注可以参考[^second]。
+  [^second]: 其他脚注。
   ```
 
 - 转义可以通过添加 `\` 来完成：

--- a/docs/src/zh/icon.md
+++ b/docs/src/zh/icon.md
@@ -20,10 +20,10 @@ mdIt.render("iPhone is made by ::apple::.");
 
 ## 语法
 
-使用 `::icon classes::` 插入自定义图标。默认情况下，插件将使用给定的图标类渲染一个 `<i>` 标签。任何以 `=` 开头的类将被视为大小定义，`/` 将被视为颜色定义：
+使用 `::icon classes::` 插入自定义图标。默认情况下，插件会渲染一个以原始内容作为 class 的 `<i>` 标签。通过 `render` 选项使用内置渲染器（`defaultRender`、`iconifyRender`、`fontawesomeRender` 和 `iconfontRender`）时，任何以 `=` 开头的部分会被视为大小定义，以 `/` 开头的部分会被视为颜色定义：
 
 ```md
-<!-- <i class="icon1" style="font-size:16px;color:red" -->
+<!-- 使用 `render: defaultRender` 时：<i icon="icon1" style="font-size:16px;color:red"></i> -->
 
 ::icon1 =16 /red::
 ```

--- a/docs/src/zh/img-size.md
+++ b/docs/src/zh/img-size.md
@@ -15,7 +15,7 @@ import { legacyImgSize, imgSize, obsidianImgSize } from "@mdit/plugin-img-size";
 
 // 新格式
 const mdNew = MarkdownIt().use(imgSize);
-mdNew.render("![image =300x200](https://example.com/image.png =300x200)");
+mdNew.render("![image =300x200](https://example.com/image.png)");
 
 // Obsidian 格式
 const mdObsidian = MarkdownIt().use(obsidianImgSize);

--- a/docs/src/zh/include.md
+++ b/docs/src/zh/include.md
@@ -34,6 +34,7 @@ mdIt.render("<!-- @include: ./path/to/include/file.md -->", {
 例如，以下代码添加了对 `@src` 别名的支持：
 
 ```ts
+import { join } from "node:path";
 import MarkdownIt from "markdown-it";
 import { include } from "@mdit/plugin-include";
 
@@ -46,7 +47,7 @@ mdIt.use(include, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return path.join(cwd, path);
+    return join(cwd, path);
   },
 });
 ```
@@ -137,7 +138,7 @@ const mdIt = MarkdownIt().use(include, {
 });
 // #endregion snippet
 
-mdIt.render("<!-- @include: ./path/to/include/file.md)", {
+mdIt.render("<!-- @include: ./path/to/include/file.md -->", {
   filePath: "path/to/current/file.md",
 });
 ```
@@ -155,7 +156,7 @@ const mdIt = MarkdownIt().use(include, {
 });
 // #endregion snippet
 
-mdIt.render("<!-- @include: ./path/to/include/file.md)", {
+mdIt.render("<!-- @include: ./path/to/include/file.md -->", {
   filePath: "path/to/current/file.md",
 });
 ```

--- a/docs/src/zh/include.md
+++ b/docs/src/zh/include.md
@@ -47,7 +47,7 @@ mdIt.use(include, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return join(cwd, path);
+    return cwd ? join(cwd, path) : path;
   },
 });
 ```

--- a/docs/src/zh/inline-rule.md
+++ b/docs/src/zh/inline-rule.md
@@ -18,6 +18,7 @@ const mdIt = MarkdownIt().use(inlineRule, {
   tag: "mark",
   token: "mark",
   nested: true,
+  double: true,
   placement: "before-emphasis",
 });
 
@@ -96,6 +97,7 @@ md.use(inlineRule, {
   tag: "span",
   token: "spoiler",
   nested: true,
+  double: true,
   placement: "before-emphasis",
   attrs: [["class", "spoiler"]],
 });
@@ -124,13 +126,14 @@ md.use(inlineRule, {
 
 ```ts
 md.use(inlineRule, {
-  marker: "?",
+  marker: "%",
   tag: "span",
   token: "help",
   nested: true,
+  double: true,
   placement: "before-emphasis",
   attrs: [["class", "help-text"]],
 });
 
-// ??帮助文本?? → <span class="help-text">帮助文本</span>
+// %%帮助文本%% → <span class="help-text">帮助文本</span>
 ```

--- a/docs/src/zh/katex.md
+++ b/docs/src/zh/katex.md
@@ -62,7 +62,7 @@ Euler’s identity $e^{i\pi}+1=0$ is a beautiful formula in $\mathbb{R}^2$.
 
 $$
 \frac {\partial^r} {\partial \omega^r} \left(\frac {y^{\omega}} {\omega}\right)
-= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^ Ir \cdots (r-i+1) (\log y)^{ri}} {\omega^i} \right\}
+= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^i r \cdots (r-i+1) (\log y)^{r-i}} {\omega^i} \right\}
 $$
 
 :::

--- a/docs/src/zh/mathjax.md
+++ b/docs/src/zh/mathjax.md
@@ -143,7 +143,7 @@ Euler’s identity $e^{i\pi}+1=0$ is a beautiful formula in $\mathbb{R}^2$.
 
 $$
 \frac {\partial^r} {\partial \omega^r} \left(\frac {y^{\omega}} {\omega}\right)
-= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^ Ir \cdots (r-i+1) (\log y)^{ri}} {\omega^i} \right\}
+= \left(\frac {y^{\omega}} {\omega}\right) \left\{(\log y)^r + \sum_{i=1}^r \frac {(-1)^i r \cdots (r-i+1) (\log y)^{r-i}} {\omega^i} \right\}
 $$
 
 :::

--- a/docs/src/zh/snippet.md
+++ b/docs/src/zh/snippet.md
@@ -47,7 +47,7 @@ mdIt.use(snippet, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return join(cwd, path);
+    return cwd ? join(cwd, path) : path;
   },
 });
 ```

--- a/docs/src/zh/snippet.md
+++ b/docs/src/zh/snippet.md
@@ -34,6 +34,7 @@ mdIt.render("<<< example.ts", {
 例如，以下代码添加了对 `@src` 别名的支持：
 
 ```ts
+import { join } from "node:path";
 import MarkdownIt from "markdown-it";
 import { snippet } from "@mdit/plugin-snippet";
 
@@ -46,7 +47,7 @@ mdIt.use(snippet, {
       return path.replace("@src", "path/to/src/folder");
     }
 
-    return path.join(cwd, path);
+    return join(cwd, path);
   },
 });
 ```

--- a/docs/src/zh/stylize.md
+++ b/docs/src/zh/stylize.md
@@ -58,7 +58,7 @@ mdIt.use(stylize, {
 mdIt.use(stylize, {
   config: [
     {
-      matcher: /^不/,
+      matcher: /^[不没]/,
       replacer: ({ tag, attrs, content }) => {
         if (tag === "em")
           return {

--- a/docs/src/zh/tex.md
+++ b/docs/src/zh/tex.md
@@ -76,8 +76,6 @@ type TexRender = (content: string, displayMode: boolean, env: MarkdownItEnv) => 
 - 必填：是
 - 详情：Tex 渲染函数。接收内容、显示模式和环境变量，返回渲染后的字符串。
 
-<!-- #endregion options -->
-
 ## 格式
 
 插件根据 `delimiters` 选项支持不同的分隔符语法：
@@ -441,14 +439,18 @@ $$
 $$
 
 ```md
-$\tag{1} x+y^{2x}$
+$$
+\tag{1} x+y^{2x}
+$$
 
-$\tag*{1} x+y^{2x}$
+$$
+\tag*{1} x+y^{2x}
+$$
 ```
 
 ### 分段函数
 
-使用 `case` 环境
+使用 `cases` 环境
 
 $$
 y= \begin{cases}


### PR DESCRIPTION
Part 2 of a 5-PR split from a full docs audit (en+zh). Every fix here addresses an example, demo, or claim that provably does not produce what the page shows — each was render-verified against the actual plugin source (markdown-it 14, default preset) before and after the change.

## Fixes

- **sub.md**: Demo wrote `H~~2~~O`, which renders as strikethrough `H<s>2</s>O` on the site (GFM strikethrough), not subscript → `H~2~O` (zh was already correct).
- **field.md + zh**: "Nested Fields" demo used `@child@` at the same depth, rendering two siblings → `@@child@`, which actually nests (verified `data-level="2"` inner `<dl>`).
- **zh/footnote.md**: definition lines used full-width colons (`：`), so the example produced no footnotes at all → ASCII `:`.
- **img-size.md + zh**: New Syntax usage kept a legacy trailing ` =300x200` after the URL, so the line failed to parse as an image entirely → removed.
- **inline-rule.md + zh**: Usage and spoiler examples omitted `double: true`, so they rendered doubly-nested `<mark><mark>…`/`<span><span>…` instead of the claimed single tag → added. The "Custom syntax" example used marker `?`, which is not in markdown-it's text-rule terminator set and can never match → switched to `%` (`%%help text%%`), verified to render the claimed output.
- **tex.md + zh**: Numbering demo's code block showed inline `$\tag{1} …$`, a hard KaTeX parse error (`\tag` is display-only) → display `$$…$$` form matching the live demo; "`case` environment" → `cases`; en-only stray spaces `` `\ div` `` → `` `\div` `` and `` `\ lVert\rVert` `` → `` `\lVert\rVert` ``.
- **tex.md / katex.md / mathjax.md + zh**: corrupted demo formula `(-1)^ Ir \cdots (\log y)^{ri}` (renders as wrong math) → the intended `(-1)^i r \cdots (r-i+1) (\log y)^{r-i}` in all five remaining copies (zh/tex.md had already been fixed).
- **tex.md**: `<!-- #endregion options -->` sat after `### render`, so **katex.md's** `@include` of that region documented a required `render` option that `MarkdownItKatexOptions` doesn't have → moved before `### render` (matching zh); removed zh's orphaned duplicate marker.
- **anchor.md + zh**: all four preset **Output** lines omitted the `tabindex="-1"`/`class="header-anchor"` attributes the documented defaults actually add → replaced with the real rendered output. The `linkAfterHeader` example called it bare, which throws (`Cannot read properties of undefined`) → now a working configured call (`assistiveText` + `visuallyHiddenClass`) with its real output.
- **icon.md + zh**: Syntax section claimed the zero-config default parses `=`/`/` size/color — it doesn't (zero-config renders `<i class="icon1 =16 /red"></i>`); parsing lives in the bundled renderers passed via `render`. Reworded and corrected the example comment to `defaultRender`'s actual output.
- **embed.md + zh**: `config` documented as `Default: []` but the plugin throws when it's missing or not an array → `Required: Yes` with a note.
- **zh/stylize.md**: prose claims both 没有 and 不要 turn red but the matcher `/^不/` only matches 不要 → `/^[不没]/` (render-verified both now match).
- **include.md / snippet.md + zh (4 files)**: `resolvePath` example called `path.join(cwd, path)` where `path` is the shadowing string parameter — a TypeError if copied verbatim → `import { join } from "node:path"` + `join(cwd, path)`.
- **zh/include.md**: two render calls had unterminated include directives (`…file.md)"` instead of `…file.md -->"`) → fixed.
- **abbr.md + zh**: demo text "specificationis" → "specification is".

Sibling PRs edit some of the same files — expect trivial merge conflicts; merge in any order and rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

**Update 2:** the embed.md / zh/embed.md hunks (`config` `Default: []` → `Required: Yes` and the zh option-entry formatting) were reverted out of this PR (`3ab3434f`) — the underlying issue is a type/runtime mismatch in the plugin itself, now fixed together with the docs in #620 so types, runtime, and docs land aligned.
