### PR TITLE
fix(plugin-embed): require config option in types

### DIFF
--- a/docs/src/embed.md
+++ b/docs/src/embed.md
@@ -147,7 +147,7 @@ interface EmbedConfig {
 }
 ```
 
-- Default: `[]`
+- Required: Yes
 - Details: An array of embed configurations.
 
 Each configuration must have:

--- a/docs/src/zh/embed.md
+++ b/docs/src/zh/embed.md
@@ -124,10 +124,7 @@ const md = MarkdownIt().use(embed, {
 
 ### config
 
-- 类型: `EmbedConfig[]`
-- 默认值: `[]`
-
-嵌入配置数组。
+- 类型：`EmbedConfig[]`
 
 ```ts
 interface EmbedConfig {
@@ -151,6 +148,9 @@ interface EmbedConfig {
   allowInline?: boolean;
 }
 ```
+
+- 必填：是
+- 详情：嵌入配置数组。
 
 每个配置必须包含：
 

--- a/packages/plugin-embed/src/options.ts
+++ b/packages/plugin-embed/src/options.ts
@@ -29,5 +29,5 @@ export interface MarkdownItEmbedOptions {
    *
    * 嵌入配置
    */
-  config?: EmbedConfig[];
+  config: EmbedConfig[];
 }


### PR DESCRIPTION
`MarkdownItEmbedOptions.config` was declared optional (`config?: EmbedConfig[]`) while the runtime unconditionally requires it — `plugin.ts` throws `TypeError: [@mdit/plugin-embed]: config is required and must be an array.` when it is missing or not an array, and the test suite codifies that behavior ("should throw without options"). The optional marker let TypeScript users write code that type-checks but crashes at runtime.

### Changes

- `packages/plugin-embed/src/options.ts`: `config?: EmbedConfig[]` → `config: EmbedConfig[]`, matching the runtime check (and the convention used by e.g. `MarkdownItUMLOptions`, whose runtime-required options are non-optional). Type-only; no runtime change.
- `docs/src/embed.md`: the option was documented as `Default: []` — there is no such default (the plugin throws) → now `Required: Yes`.
- `docs/src/zh/embed.md`: same correction, plus aligning the option entry with the en layout and repo zh conventions (full-width `类型：/必填：/详情：`, type-definition block directly after the Type line).

Notes:

- markdown-it's `use()` is loosely typed, so `md.use(embed, {})` still compiles regardless of this change (it keeps failing fast at runtime, as the existing test asserts — no `@ts-expect-error` needed). The required type protects direct uses of `MarkdownItEmbedOptions` and typed wrappers.
- Technically a breaking type change for consumers who omitted `config` in a typed context — such code was already throwing at runtime.
- Split out of #619 per review discussion there (the docs-only PR reverted its embed hunks in favor of this combined fix, so types + runtime + docs land together).

`pnpm vitest run packages/plugin-embed` (39 passed) and `pnpm type-check` are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
