### PR TITLE
fix(plugin-stylize): guard replacer result fields

### DIFF
--- a/packages/plugin-stylize/__tests__/stylize.spec.ts
+++ b/packages/plugin-stylize/__tests__/stylize.spec.ts
@@ -225,6 +225,37 @@ describe(stylize, () => {
       // Standard markdown tags usually have null attrs
       expect(markdownItAttrs.render("**TEST**")).toBe("<p><strong>TEST!</strong></p>\n");
     });
+
+    it("should not throw when replacer returns a result without attrs", () => {
+      const markdownItMissingAttrs = MarkdownIt().use(stylize, {
+        config: [
+          {
+            matcher: "TEST",
+            replacer: ({ tag, content }): MarkdownItStylizeResult =>
+              ({ tag, content }) as MarkdownItStylizeResult,
+          },
+        ],
+      });
+
+      // Replacer omitting `attrs` should not crash on Object.entries(undefined)
+      expect(markdownItMissingAttrs.render("**TEST**")).toBe("<p><strong>TEST</strong></p>\n");
+    });
+
+    it("should keep original content when replacer returns a result without content", () => {
+      const markdownItMissingContent = MarkdownIt().use(stylize, {
+        config: [
+          {
+            matcher: "TEST",
+            replacer: ({ tag, attrs }): MarkdownItStylizeResult =>
+              ({ tag, attrs }) as MarkdownItStylizeResult,
+          },
+        ],
+      });
+
+      // Replacer omitting `content` should fall back to the original text
+      // instead of rendering the literal string "undefined"
+      expect(markdownItMissingContent.render("**TEST**")).toBe("<p><strong>TEST</strong></p>\n");
+    });
   });
 
   describe("localConfigGetter", () => {

--- a/packages/plugin-stylize/src/plugin.ts
+++ b/packages/plugin-stylize/src/plugin.ts
@@ -38,8 +38,9 @@ const scanTokens = (tokens: Token[], config: MarkdownItStylizeConfig[]): void =>
 
       if (result) {
         tokenPrev.tag = tokenNext.tag = result.tag;
-        tokenPrev.attrs = Object.entries(result.attrs);
-        token.content = result.content;
+        // Guard against user replacers omitting optional fields at runtime
+        tokenPrev.attrs = Object.entries(result.attrs ?? {});
+        token.content = result.content ?? token.content;
       }
 
       // skip 2 tokens


### PR DESCRIPTION
## Problem

When a user-supplied `replacer` returns a result object missing fields at runtime, the plugin crashes or produces incorrect output:

1. **Missing `attrs`** → `Object.entries(undefined)` throws a `TypeError`, crashing the whole render (verified).
2. **Missing `content`** → the token's content is set to `undefined`, rendering the literal string `undefined` (e.g. `<strong>undefined</strong>`) instead of preserving the original text (verified).

## Fix

Add runtime fallbacks in `scanTokens` for these common replacer omissions:

- `tokenPrev.attrs = Object.entries(result.attrs ?? {})` — treat a missing `attrs` as an empty attribute set instead of crashing.
- `token.content = result.content ?? token.content` — preserve the original matched text when `content` is missing (falling back to the middle text token's content, not the open token).

## Tests

- Added 2 regression tests simulating replacers missing `attrs` and `content` respectively.
- Before the fix: both tests failed (one throws `TypeError`, the other outputs `undefined`).
- After the fix: all pass.
- Coverage: `plugin-stylize` 100% statements / branches / functions / lines.