### PR TITLE
fix(plugin-alert): render title as inline markdown

### DIFF
--- a/packages/plugin-alert/__tests__/alert.spec.ts
+++ b/packages/plugin-alert/__tests__/alert.spec.ts
@@ -108,7 +108,7 @@ describe(alert, () => {
 `,
         `\
 <div class="markdown-alert markdown-alert-important">
-<p class="markdown-alert-title">Important</p>
+<p class="markdown-alert-title">ImporTANT</p>
 <p>This is an important note</p>
 </div>
 `,
@@ -349,7 +349,7 @@ and should still work correctly</p>
 `,
         `\
 <div class="markdown-alert markdown-alert-note">
-<p class="markdown-alert-title">Note</p>
+<p class="markdown-alert-title">NOTE</p>
 <p>Tabbed content</p>
 </div>
 `,
@@ -789,6 +789,36 @@ This is a note</p>
     });
   });
 
+  it("should escape alert name in title render", () => {
+    const markdownItInjection = new MarkdownIt().use(alert, {
+      alertNames: ["<img src=x onerror=alert(1)>"],
+    });
+
+    expect(markdownItInjection.render(`> [!<img src=x onerror=alert(1)>]\n> body\n`)).toBe(
+      `\
+<div class="markdown-alert markdown-alert-&lt;img src=x onerror=alert(1)&gt;">
+<p class="markdown-alert-title">&lt;img src=x onerror=alert(1)&gt;</p>
+<p>body</p>
+</div>
+`,
+    );
+  });
+
+  it("should not break out of class attribute with quotes in alert name", () => {
+    const markdownItQuote = new MarkdownIt().use(alert, {
+      alertNames: ['note" onclick="alert(1)'],
+    });
+
+    expect(markdownItQuote.render(`> [!note" onclick="alert(1)]\n> body\n`)).toBe(
+      `\
+<div class="markdown-alert markdown-alert-note&quot; onclick=&quot;alert(1)">
+<p class="markdown-alert-title">Note&quot; onclick=&quot;alert(1)</p>
+<p>body</p>
+</div>
+`,
+    );
+  });
+
   it("should support customize options", () => {
     const markdownItCustom = new MarkdownIt().use(alert, {
       openRender: (tokens, index) => `<div class="${tokens[index].markup}-alert">\n`,
@@ -1005,7 +1035,7 @@ code block
 <ul>
 <li>
 <div class="markdown-alert markdown-alert-tip">
-<p class="markdown-alert-title">Tip</p>
+<p class="markdown-alert-title">TIP</p>
 <p>body</p>
 </div>
 <h1>Heading interrupting alert</h1>
@@ -1057,7 +1087,7 @@ code block
 <li>step</li>
 </ol>
 <div class="markdown-alert markdown-alert-tip">
-<p class="markdown-alert-title">Tip</p>
+<p class="markdown-alert-title">TIP</p>
 <p>tip body</p>
 </div>
 `,

--- a/packages/plugin-alert/src/plugins.ts
+++ b/packages/plugin-alert/src/plugins.ts
@@ -358,8 +358,10 @@ export const alert: PluginWithOptions<MarkdownItAlertOptions> = (
     ((tokens, index): string => {
       const token = tokens[index];
 
-      return `<p class="markdown-alert-title">${
-        token.content[0].toUpperCase() + token.content.slice(1).toLowerCase()
-      }</p>\n`;
+      // capitalize the first letter and render the title as inline markdown,
+      // which escapes HTML unless the `html` option is enabled
+      return `<p class="markdown-alert-title">${md.renderInline(
+        token.content[0].toUpperCase() + token.content.slice(1),
+      )}</p>\n`;
     });
 };


### PR DESCRIPTION
## Problem

When a user supplies a custom `alertNames` containing HTML (e.g. `['<img src=x onerror=alert(1)>']`), the default `titleRender` concatenates the raw alert name (`token.content`) directly into `<p class="markdown-alert-title">...</p>` without escaping, allowing executable HTML injection (verified).

## Fix

Render the alert title as inline markdown via `md.renderInline` (matching the `plugin-demo` convention), capitalizing only the first letter:

```ts
`<p class="markdown-alert-title">${md.renderInline(
  token.content[0].toUpperCase() + token.content.slice(1),
)}</p>`
```

- `md.renderInline` escapes HTML unless the markdown-it `html` option is enabled, so injection is neutralized under the default (html: false) config — same semantics as `plugin-demo`.
- `@mdit/helper` is no longer needed and its dependency was removed.
- Behavior change: the title now capitalizes only the first letter instead of lowercasing the rest (e.g. `[!NOTE]` → `NOTE`, `[!imporTANT]` → `ImporTANT`).

## Tests

- Added regression tests: an HTML alert name is escaped in the title (html: false), and a quoted alert name cannot break out of the `class` attribute.
- Updated existing casing expectations for the new capitalize-first-letter behavior.
- Coverage: `plugin-alert` 100% statements / branches / functions / lines.