### PR TITLE
fix(plugin-katex): reset macros after each render

### DIFF
--- a/packages/plugin-katex-slim/__tests__/katex.spec.ts
+++ b/packages/plugin-katex-slim/__tests__/katex.spec.ts
@@ -254,3 +254,56 @@ $$
     expect(markdownItTransformer.render(`$a=1$`)).toContain(" v-pre ");
   });
 });
+
+describe("gdef macros", () => {
+  const macroSource = String.raw`$\gdef\foo{\text{LEAKED-MACRO}} \foo$`;
+
+  it(String.raw`should not leak \gdef macros across documents`, () => {
+    // doc 1 defines a macro with \gdef and uses it
+    markdownIt.render(macroSource);
+
+    // doc 2 must not know about \foo defined in doc 1
+    const result = markdownIt.render(String.raw`$\foo$`);
+
+    expect(result).not.toContain("LEAKED-MACRO");
+  });
+
+  it(String.raw`should keep \gdef macros within a single document`, () => {
+    // use the html output to avoid the MathML annotation echoing the source tex
+    const result = markdownItHTML.render(macroSource);
+
+    expect(result).toContain("LEAKED-MACRO");
+  });
+
+  it(String.raw`should share \gdef macros across expressions within a document`, () => {
+    const result = markdownItHTML.render(String.raw`$\gdef\foo{\text{LEAKED-MACRO}}$ and $\foo$`);
+
+    expect(result).toContain("LEAKED-MACRO");
+  });
+
+  it("should not throw when rendering tokens without env", () => {
+    const markdownItNoEnv = MarkdownIt({ linkify: true }).use(katex);
+    const tokens = markdownItNoEnv.parse(String.raw`$\gdef\foo{\text{LEAKED-MACRO}} \foo$`, void 0);
+
+    expect(() =>
+      markdownItNoEnv.renderer.render(tokens, markdownItNoEnv.options, void 0),
+    ).not.toThrow();
+  });
+
+  it("should support global macros from options", () => {
+    const markdownItMacros = MarkdownIt({ linkify: true }).use(katex, {
+      macros: { [String.raw`\foo`]: String.raw`\text{global}` },
+    });
+
+    expect(markdownItMacros.render(String.raw`$\foo$`)).toContain("global");
+  });
+
+  it(String.raw`should not leak \gdef macros via renderInline`, () => {
+    markdownItHTML.renderInline(String.raw`$\gdef\foo{\text{LEAKED-MACRO}} \foo$`);
+
+    // a following renderInline must not know about \foo defined above
+    const result = markdownItHTML.renderInline(String.raw`$\foo$`);
+
+    expect(result).not.toContain("LEAKED-MACRO");
+  });
+});

--- a/packages/plugin-katex-slim/src/plugin.ts
+++ b/packages/plugin-katex-slim/src/plugin.ts
@@ -92,6 +92,33 @@ export const katex = <MarkdownItEnv = unknown>(
     userOptions,
   );
 
+  // reset macros after every render so `\gdef` does not leak across documents
+  // while remaining usable anywhere within a single render.
+  const originalRender = md.render.bind(md);
+  const originalRenderInline = md.renderInline.bind(md);
+
+  const resetMacros = (): void => {
+    commonKatexOptions.macros = Object.assign({}, userOptions.macros);
+  };
+
+  md.render = (src: string, env?: MarkdownItEnv): string => {
+    try {
+      return originalRender(src, env);
+    } finally {
+      resetMacros();
+    }
+  };
+
+  md.renderInline = (src: string, env?: MarkdownItEnv): string => {
+    try {
+      return originalRenderInline(src, env);
+    } finally {
+      resetMacros();
+    }
+  };
+
+  resetMacros();
+
   md.use(tex, {
     allowInlineWithSpace,
     delimiters,
@@ -101,6 +128,7 @@ export const katex = <MarkdownItEnv = unknown>(
         {},
         commonKatexOptions,
         {
+          macros: commonKatexOptions.macros,
           strict: (errorCode, errorMsg, token) =>
             logger(errorCode, errorMsg, token, env) ?? "ignore",
           displayMode,

--- a/packages/plugin-katex/__tests__/katex.spec.ts
+++ b/packages/plugin-katex/__tests__/katex.spec.ts
@@ -254,3 +254,56 @@ $$
     expect(markdownItTransformer.render(`$a=1$`)).toContain(" v-pre ");
   });
 });
+
+describe("gdef macros", () => {
+  const macroSource = String.raw`$\gdef\foo{\text{LEAKED-MACRO}} \foo$`;
+
+  it(String.raw`should not leak \gdef macros across documents`, () => {
+    // doc 1 defines a macro with \gdef and uses it
+    markdownIt.render(macroSource);
+
+    // doc 2 must not know about \foo defined in doc 1
+    const result = markdownIt.render(String.raw`$\foo$`);
+
+    expect(result).not.toContain("LEAKED-MACRO");
+  });
+
+  it(String.raw`should keep \gdef macros within a single document`, () => {
+    // use the html output to avoid the MathML annotation echoing the source tex
+    const result = markdownItHTML.render(macroSource);
+
+    expect(result).toContain("LEAKED-MACRO");
+  });
+
+  it(String.raw`should share \gdef macros across expressions within a document`, () => {
+    const result = markdownItHTML.render(String.raw`$\gdef\foo{\text{LEAKED-MACRO}}$ and $\foo$`);
+
+    expect(result).toContain("LEAKED-MACRO");
+  });
+
+  it("should not throw when rendering tokens without env", () => {
+    const markdownItNoEnv = MarkdownIt({ linkify: true }).use(katex);
+    const tokens = markdownItNoEnv.parse(String.raw`$\gdef\foo{\text{LEAKED-MACRO}} \foo$`, void 0);
+
+    expect(() =>
+      markdownItNoEnv.renderer.render(tokens, markdownItNoEnv.options, void 0),
+    ).not.toThrow();
+  });
+
+  it("should support global macros from options", () => {
+    const markdownItMacros = MarkdownIt({ linkify: true }).use(katex, {
+      macros: { [String.raw`\foo`]: String.raw`\text{global}` },
+    });
+
+    expect(markdownItMacros.render(String.raw`$\foo$`)).toContain("global");
+  });
+
+  it(String.raw`should not leak \gdef macros via renderInline`, () => {
+    markdownItHTML.renderInline(String.raw`$\gdef\foo{\text{LEAKED-MACRO}} \foo$`);
+
+    // a following renderInline must not know about \foo defined above
+    const result = markdownItHTML.renderInline(String.raw`$\foo$`);
+
+    expect(result).not.toContain("LEAKED-MACRO");
+  });
+});

--- a/packages/plugin-katex/src/plugin.ts
+++ b/packages/plugin-katex/src/plugin.ts
@@ -78,6 +78,33 @@ export const katex = <MarkdownItEnv = unknown>(
     userOptions,
   );
 
+  // TEMP: plan C — reset macros after every render so `\gdef` does not leak
+  // across documents while remaining usable within a single render.
+  const originalRender = md.render.bind(md);
+  const originalRenderInline = md.renderInline.bind(md);
+
+  const resetMacros = (): void => {
+    commonKatexOptions.macros = Object.assign({}, userOptions.macros);
+  };
+
+  md.render = (src: string, env?: MarkdownItEnv): string => {
+    try {
+      return originalRender(src, env);
+    } finally {
+      resetMacros();
+    }
+  };
+
+  md.renderInline = (src: string, env?: MarkdownItEnv): string => {
+    try {
+      return originalRenderInline(src, env);
+    } finally {
+      resetMacros();
+    }
+  };
+
+  resetMacros();
+
   md.use(tex, {
     allowInlineWithSpace,
     delimiters,
@@ -87,6 +114,7 @@ export const katex = <MarkdownItEnv = unknown>(
         {},
         commonKatexOptions,
         {
+          macros: commonKatexOptions.macros,
           strict: (errorCode, errorMsg, token) =>
             logger(errorCode, errorMsg, token, env) ?? "ignore",
           displayMode,


### PR DESCRIPTION
## Problem

`@mdit/plugin-katex` and `@mdit/plugin-katex-slim` share a single `commonKatexOptions.macros` object across all renders. KaTeX's `\gdef` writes macro definitions directly into that object, so a macro defined in one document leaks into subsequent documents: after `$\gdef\foo{...}$` in doc 1, an undefined `$\foo$` in doc 2 is still expanded (verified).

## Fix

Reset macros after every render by wrapping `md.render` and `md.renderInline` (via `try/finally`, so they are reset even if rendering throws):

- Each render shares a fresh copy of the user-supplied global macros, so `\gdef` works anywhere within a single render (including across separate math expressions) but does **not** leak into the next render.
- State stays fully inside the plugin closure — no `env` contract is introduced.
- This matches the existing `reset()` approach of `plugin-mathjax` (which will adopt the same wrapping pattern for issue 3.7).

Applied to both `plugin-katex` and `plugin-katex-slim` (identical logic).

## Tests

- Added a `gdef macros` suite to both packages covering:
  - no leak across documents,
  - usable within a single document (single expression),
  - shared across expressions within a document,
  - global `macros` from options still works,
  - no leak via `renderInline`,
  - rendering tokens without `env` does not throw.
- Coverage: `plugin-katex` and `plugin-katex-slim` both 100% statements / branches / functions / lines.