### PR TITLE
fix(plugin-uml): escape info in default render

### DIFF
--- a/packages/plugin-uml/__tests__/uml.spec.ts
+++ b/packages/plugin-uml/__tests__/uml.spec.ts
@@ -106,6 +106,20 @@ Text with **bold** and \`code\`.
 `);
   });
 
+  it("should escape info in default render", () => {
+    const markdownIt = MarkdownIt({ linkify: true }).use(uml);
+
+    expect(
+      markdownIt.render(`
+@start" onclick="alert(1)
+abc
+@end
+    `),
+    ).toBe(`\
+<div class="uml" title="&quot; onclick=&quot;alert(1)">abc</div>\
+`);
+  });
+
   it("should render with options", () => {
     const markdownIt = MarkdownIt({ linkify: true }).use(uml, {
       name: "test",

--- a/packages/plugin-uml/src/options.ts
+++ b/packages/plugin-uml/src/options.ts
@@ -1,3 +1,4 @@
+import { escapeHtml } from "@mdit/helper";
 import type { RenderRule } from "markdown-it/lib/renderer.mjs";
 import type Token from "markdown-it/lib/token.mjs";
 
@@ -34,5 +35,6 @@ export interface MarkdownItUMLOptions {
 export const defaultRender = (tokens: Token[], index: number): string => {
   const token = tokens[index];
 
-  return `<div class="${token.type}" title="${token.info}">${token.content}</div>`;
+  // escapeHtml so `info` (user-controlled) cannot escape the title attribute
+  return `<div class="${token.type}" title="${escapeHtml(token.info)}">${token.content}</div>`;
 };


### PR DESCRIPTION
## Problem

The `defaultRender` of `@mdit/plugin-uml` concatenates the user-controlled `token.info` (the raw params after the `@start` marker) directly into the `title` attribute:

```ts
return `<div class="${token.type}" title="${token.info}">${token.content}</div>`;
```

Input like `@start" onclick="alert(1)` escapes the `title` attribute and injects an `onclick` handler (verified):

```html
<div class="uml" title="" onclick="alert(1)">content</div>
```

## Fix

Escape `token.info` with `escapeHtml` (from `@mdit/helper`) in `defaultRender` so it cannot escape the `title` attribute. `token.content` stays untouched (it is block content passed through into the `<div>`, not an attribute). `@mdit/helper` was already a dependency (used by `plugin.ts` for `dedent`).

## Tests

- Added a regression test: `@start" onclick="alert(1)` now renders `title="&quot; onclick=&quot;alert(1)"`.
- Coverage: `plugin-uml` 100% statements / branches / functions / lines.