### PR TITLE
fix(plugin-layout): keep @end trailing content

### DIFF
--- a/packages/plugin-layout/__tests__/directive.spec.ts
+++ b/packages/plugin-layout/__tests__/directive.spec.ts
@@ -3,10 +3,17 @@ import { describe, expect, it } from "vitest";
 import { detectDirective, parseAttributes } from "../src/directive.js";
 
 describe(detectDirective, () => {
-  it("should detect @end with trailing space", () => {
-    const result = detectDirective("@end trailing", 0, 13);
+  it("should detect @end followed by only spaces", () => {
+    expect(detectDirective("@end  ", 0, 6)).toStrictEqual({
+      kind: "end",
+      type: 0,
+      nameEnd: 4,
+      depth: 1,
+    });
+  });
 
-    expect(result).toStrictEqual({ kind: "end", type: 0, nameEnd: 4, depth: 1 });
+  it("should not detect @end with trailing content as end", () => {
+    expect(detectDirective("@end trailing", 0, 13)).toBeNull();
   });
 
   it("should not detect @endfoo as end", () => {

--- a/packages/plugin-layout/__tests__/layout.spec.ts
+++ b/packages/plugin-layout/__tests__/layout.spec.ts
@@ -124,6 +124,38 @@ Content
 </div>
 `);
       });
+
+      it("should not treat @end with trailing content as a valid end", () => {
+        expect(
+          markdownIt.render(`\
+@flexs
+content
+@end garbage
+`),
+        ).toBe(`\
+<div style="display:flex">
+<p>content
+@end garbage</p>
+</div>
+`);
+      });
+
+      it("should auto-close container to EOF when @end has trailing content", () => {
+        expect(
+          markdownIt.render(`\
+@flexs
+content
+@end garbage
+After
+`),
+        ).toBe(`\
+<div style="display:flex">
+<p>content
+@end garbage
+After</p>
+</div>
+`);
+      });
     });
 
     describe("empty", () => {

--- a/packages/plugin-layout/src/directive.ts
+++ b/packages/plugin-layout/src/directive.ts
@@ -68,9 +68,13 @@ export const detectDirective = (
   // Check for "end"
   if (matchString(src, afterAt, END) && afterAt + END.length <= max) {
     const endPos = afterAt + END.length;
+    let spaceEnd = endPos;
 
-    if (endPos >= max || src.charCodeAt(endPos) === SPACE)
-      return { kind: "end", type: 0, nameEnd: endPos, depth };
+    // `@end` must be followed by only whitespace or end of line, otherwise the
+    // trailing content would be silently dropped.
+    while (spaceEnd < max && src.charCodeAt(spaceEnd) === SPACE) spaceEnd++;
+
+    if (spaceEnd >= max) return { kind: "end", type: 0, nameEnd: endPos, depth };
   }
 
   // Check for "flex" / "flexs"


### PR DESCRIPTION
## Problem

`detectDirective` treated `@end garbage` (an `@end` marker with non-whitespace trailing content) as a valid closing directive: the check only required the next char to be a space. The trailing content was silently dropped (verified: `@end garbage` and `@end` produced identical output).

## Fix

In `detectDirective`, `@end` is only recognized as a closing directive when it is followed by only whitespace or the end of line; otherwise it is not treated as a close, so trailing content is no longer silently dropped (the container auto-closes at the end of the document and the `@end garbage` line is kept as content).

## Tests

- Updated `directive.spec.ts`: `@end` followed by only spaces is detected as `end`; `@end trailing` now returns `null`.
- Added integration tests in `layout.spec.ts`: `@end garbage` no longer closes the container (content preserved), and the container auto-closes to EOF keeping subsequent content.
- Coverage: `plugin-layout` 100% statements / branches / functions / lines.