### PR TITLE
fix(plugin-layout): preserve @end trailing content

### DIFF
--- a/packages/plugin-layout/__tests__/directive.spec.ts
+++ b/packages/plugin-layout/__tests__/directive.spec.ts
@@ -3,10 +3,30 @@ import { describe, expect, it } from "vitest";
 import { detectDirective, parseAttributes } from "../src/directive.js";
 
 describe(detectDirective, () => {
-  it("should detect @end with trailing space", () => {
-    const result = detectDirective("@end trailing", 0, 13);
+  it("should detect bare @end", () => {
+    expect(detectDirective("@end", 0, 4)).toStrictEqual({
+      kind: "end",
+      type: 0,
+      nameEnd: 4,
+      depth: 1,
+    });
+  });
 
-    expect(result).toStrictEqual({ kind: "end", type: 0, nameEnd: 4, depth: 1 });
+  it("should detect @end followed by trailing whitespace", () => {
+    expect(detectDirective("@end  ", 0, 6)).toStrictEqual({
+      kind: "end",
+      type: 0,
+      nameEnd: 4,
+      depth: 1,
+    });
+  });
+
+  it("should not detect @end with trailing content as end", () => {
+    expect(detectDirective("@end trailing", 0, 13)).toBeNull();
+  });
+
+  it("should not detect @@end with trailing content as end", () => {
+    expect(detectDirective("@@end trailing", 0, 14)).toBeNull();
   });
 
   it("should not detect @endfoo as end", () => {

--- a/packages/plugin-layout/__tests__/nesting.spec.ts
+++ b/packages/plugin-layout/__tests__/nesting.spec.ts
@@ -698,6 +698,47 @@ Content
     });
   });
 
+  describe("trailing content after @end", () => {
+    it("should keep @end trailing content instead of silently dropping it", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+Content
+@end garbage
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<p>Content
+@end garbage</p>
+</div>
+</div>
+`);
+    });
+
+    it("should not close container on @end trailing content and keep it as literal text", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+Content
+@end garbage
+after the garbage
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<p>Content
+@end garbage
+after the garbage</p>
+</div>
+</div>
+`);
+    });
+  });
+
   describe("markdown content", () => {
     it("should render markdown inside items", () => {
       expect(

--- a/packages/plugin-layout/src/directive.ts
+++ b/packages/plugin-layout/src/directive.ts
@@ -69,8 +69,14 @@ export const detectDirective = (
   if (matchString(src, afterAt, END) && afterAt + END.length <= max) {
     const endPos = afterAt + END.length;
 
-    if (endPos >= max || src.charCodeAt(endPos) === SPACE)
-      return { kind: "end", type: 0, nameEnd: endPos, depth };
+    // Only a bare `@end` (optionally followed by whitespace) closes a container.
+    // Trailing content after `@end` must not be silently dropped, so it is not
+    // recognized as a closing directive.
+    let endTrail = endPos;
+
+    while (endTrail < max && src.charCodeAt(endTrail) === SPACE) endTrail++;
+
+    if (endTrail >= max) return { kind: "end", type: 0, nameEnd: endPos, depth };
   }
 
   // Check for "flex" / "flexs"


### PR DESCRIPTION
## Summary

Fixes an issue in `plugin-layout` where a line like `@end garbage` was treated as a valid `@end` closing directive, causing the trailing content (`garbage`) to be **silently dropped** from the rendered output.

## Problem

In `detectDirective` (`src/directive.ts`), the `@end` branch only checked whether the character **immediately after** `@end` was a space or end-of-line:

```ts
if (endPos >= max || src.charCodeAt(endPos) === SPACE)
  return { kind: "end", type: 0, nameEnd: endPos, depth };
```

This means `@end garbage` was recognized as a closing `@end`, and `garbage` was silently discarded instead of being rendered.

## Fix

The `@end` branch now requires that everything after `@end` up to end-of-line is **whitespace only** before it is recognized as a closing directive. `@end garbage` is no longer treated as a close, so the trailing content is preserved as literal markdown text.

This also makes `@end` consistent with the other directives (e.g. `@flexs garbage`), where trailing content is handled rather than silently dropped.

## Tests

- Updated `__tests__/directive.spec.ts`:
  - `@end` (bare) and `@end` + trailing whitespace are still detected as `end`.
  - `@end trailing` and `@@end trailing` (multi-`@` prefix) are **not** detected as `end`.
- Added `__tests__/nesting.spec.ts` `trailing content after @end` suite:
  - `@end garbage` at the end of a container keeps the content as literal text.
  - Mid-document `@end garbage` does not close the container; a later real `@end` closes it and the trailing content is preserved.

## Verification

- `pnpm exec vitest run --coverage` (in `packages/plugin-layout`): **163/163 tests passing**, **100%** statements/branches/functions/lines.
- `pnpm run lint:check`: clean.
- `pnpm run type-check`: clean.
