### PR TITLE
fix(plugin-figure): never move native img attrs to figure

### DIFF
--- a/docs/src/figure.md
+++ b/docs/src/figure.md
@@ -50,6 +50,8 @@ If a image is standalone in a line, wrapped or not wrapped by link, it will be d
   - `true`: **copy** all attributes except native img ones (src, alt, srcset, width, height, loading, etc.) to `<figure>`. Image keeps them.
   - `(string | RegExp)[]`: **move** only matching attributes to `<figure>`. Image loses them.
 
+  Native img attributes (src, alt, title, width, height, etc.) are never moved or copied to `<figure>`, and `title` is always used as the `<figcaption>` content.
+
   ```ts
   // Copy all non-native attrs to figure (img keeps them)
   moveAttrs: true;

--- a/docs/src/zh/figure.md
+++ b/docs/src/zh/figure.md
@@ -50,6 +50,8 @@ mdIt.render("![image](https://example.com/image.png)");
   - `true`：**复制**除原生 img 属性（src、alt、srcset、width、height、loading 等）外的所有属性到 `<figure>`，图片保留这些属性。
   - `(string | RegExp)[]`：**移动**仅匹配的属性到 `<figure>`，图片失去这些属性。
 
+  原生 img 属性（src、alt、title、width、height 等）永远不会被移动或复制到 `<figure>` 上，且 `title` 始终作为 `<figcaption>` 内容显示。
+
   ```ts
   // 复制所有非原生属性到 figure（img 保留）
   moveAttrs: true;

--- a/packages/plugin-attrs/__tests__/plugin.spec.ts
+++ b/packages/plugin-attrs/__tests__/plugin.spec.ts
@@ -92,5 +92,16 @@ describe("plugin compatibility", () => {
         '<figure><img src="/logo.svg" alt="image" class="center"><figcaption>caption</figcaption></figure>\n',
       );
     });
+
+    it("should move class to figure with figure moveAttrs option", () => {
+      const md = MarkdownIt({ html: true })
+        .use(attrs)
+        .use(figure, { moveAttrs: ["class"], focusable: false });
+
+      // class added by attrs is moved onto the figure by figure's moveAttrs
+      expect(md.render(`![image](/logo.svg "caption"){.center}`)).toBe(
+        '<figure class="center"><img src="/logo.svg" alt="image"><figcaption>caption</figcaption></figure>\n',
+      );
+    });
   });
 });

--- a/packages/plugin-figure/__tests__/figure.spec.ts
+++ b/packages/plugin-figure/__tests__/figure.spec.ts
@@ -3,6 +3,25 @@ import { describe, expect, it } from "vitest";
 
 import { figure } from "../src/index.js";
 
+/**
+ * Test-only helper: add a non-native attribute to every image token before figure runs.
+ *
+ * 测试辅助：在 figure 运行前给每个图片 token 添加非原生属性。
+ *
+ * @param md - MarkdownIt instance / MarkdownIt 实例
+ * @param attr - Attribute to set / 要设置的属性
+ */
+const addImageAttr = (md: MarkdownIt, attr: [string, string]): void => {
+  md.core.ruler.before("figure", "test-image-attr", (state) => {
+    for (const token of state.tokens) {
+      if (token.type !== "inline" || !token.children) continue;
+
+      for (const child of token.children)
+        if (child.type === "image") child.attrSet(attr[0], attr[1]);
+    }
+  });
+};
+
 describe(figure, () => {
   const markdownIt = MarkdownIt({ html: true, linkify: true }).use(figure);
 
@@ -129,61 +148,114 @@ test ![image](/logo.svg)
 
   describe("moveAttrs", () => {
     it("should copy non-native attrs to figure with true", () => {
+      const md = new MarkdownIt().use(figure, { moveAttrs: true, focusable: false });
+
+      addImageAttr(md, ["class", "main"]);
+
+      // class is a non-native attr — copied to figure (img keeps it)
+      // title is a native img attr — stays as caption, never copied to figure
+      expect(md.render('![image](/logo.svg "A title")')).toBe(
+        '<figure class="main"><img src="/logo.svg" alt="image" class="main"><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should not copy native attrs to figure with true", () => {
       const md = new MarkdownIt().use(figure, {
         moveAttrs: true,
         focusable: false,
       });
 
-      // title is a global attr, not native img — copied to figure
-      // getCaption later removes title from img and uses it as caption
-      expect(md.render('![image](/logo.svg "A title")')).toBe(
-        '<figure title="A title"><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
-      );
-    });
-
-    it("should not copy native attrs with true", () => {
-      const md = new MarkdownIt().use(figure, {
-        moveAttrs: true,
-        focusable: false,
-      });
-
-      expect(md.render("![image](/logo.svg)")).toBe(
-        '<figure><img src="/logo.svg" alt="image"><figcaption>image</figcaption></figure>\n',
-      );
-    });
-
-    it("should move matching attrs to figure with array", () => {
-      const md = new MarkdownIt().use(figure, {
-        moveAttrs: ["title"],
-        focusable: false,
-      });
-
-      // title is moved from img to figure before getCaption runs
-      // getCaption can't find title on img, falls back to alt
-      expect(md.render('![image](/logo.svg "A title")')).toBe(
-        '<figure title="A title"><img src="/logo.svg" alt="image"><figcaption>image</figcaption></figure>\n',
-      );
-    });
-
-    it("should support RegExp patterns in array", () => {
-      const md = new MarkdownIt().use(figure, {
-        moveAttrs: [/^data-/],
-        focusable: false,
-      });
-
-      // No data-* attrs present, nothing moved
+      // title is a native img attr — never copied to figure, stays as caption
       expect(md.render('![image](/logo.svg "A title")')).toBe(
         '<figure><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
       );
     });
 
-    it("should not move unmatched attrs", () => {
+    it("should move matching non-native attrs to figure with array", () => {
+      const md = new MarkdownIt().use(figure, { moveAttrs: ["class"], focusable: false });
+
+      addImageAttr(md, ["class", "main"]);
+
+      // class is moved to figure (img loses it); title stays as caption
+      expect(md.render('![image](/logo.svg "A title")')).toBe(
+        '<figure class="main"><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should not move native attrs even when explicitly matched with array", () => {
       const md = new MarkdownIt().use(figure, {
-        moveAttrs: ["class"],
+        moveAttrs: ["title"],
         focusable: false,
       });
 
-      // title doesn't match "class", stays on img, then getCaption removes it
+      // title is a native img attr — never moved to figure even if explicitly listed
+      expect(md.render('![image](/logo.svg "A title")')).toBe(
+        '<figure><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should support RegExp patterns in array", () => {
+      const md = new MarkdownIt().use(figure, { moveAttrs: [/^data-/], focusable: false });
+
+      addImageAttr(md, ["data-x", "1"]);
+
+      // data-x matched by RegExp — moved to figure; title stays as caption
+      expect(md.render('![image](/logo.svg "A title")')).toBe(
+        '<figure data-x="1"><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should not move unmatched attrs", () => {
+      const md = new MarkdownIt().use(figure, { moveAttrs: ["class"], focusable: false });
+
+      // no class attr — nothing moved; title stays as caption
+      expect(md.render('![image](/logo.svg "A title")')).toBe(
+        '<figure><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should keep title as caption for linked images", () => {
+      const md = new MarkdownIt().use(figure, { moveAttrs: true, focusable: false });
+
+      addImageAttr(md, ["class", "main"]);
+
+      // title stays as caption for linked images too; class copied to figure
+      expect(md.render('[![alt](/url "A title")](https://example.com)')).toBe(
+        '<figure class="main"><a href="https://example.com"><img src="/url" alt="alt" class="main"></a><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should keep title as caption when alt is empty", () => {
+      const md = new MarkdownIt().use(figure, {
+        moveAttrs: true,
+        focusable: false,
+      });
+
+      // empty alt — title is still used as caption
+      expect(md.render('![](/url "A title")')).toBe(
+        '<figure><img src="/url" alt=""><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should not move title even when matched by a RegExp pattern", () => {
+      const md = new MarkdownIt().use(figure, {
+        moveAttrs: [/^tit/],
+        focusable: false,
+      });
+
+      // title is a native img attr — never moved even if a RegExp matches it
+      expect(md.render('![image](/logo.svg "A title")')).toBe(
+        '<figure><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
+      );
+    });
+
+    it("should not move native attrs like src or alt with array", () => {
+      const md = new MarkdownIt().use(figure, {
+        moveAttrs: ["src", "alt"],
+        focusable: false,
+      });
+
+      // src/alt are native img attrs — never moved to figure
       expect(md.render('![image](/logo.svg "A title")')).toBe(
         '<figure><img src="/logo.svg" alt="image"><figcaption>A title</figcaption></figure>\n',
       );

--- a/packages/plugin-figure/src/options.ts
+++ b/packages/plugin-figure/src/options.ts
@@ -6,10 +6,15 @@ export interface MarkdownItFigureOptions {
    *   Image keeps them.
    * - `(string | RegExp)[]`: **move** only matching attributes to `<figure>`. Image loses them.
    *
+   * Native img attributes (src, alt, title, width, height, etc.) are never moved or copied to
+   * `<figure>`.
+   *
    * 将图片属性复制或移动到 `<figure>` 上。
    *
    * - `true`：**复制**除原生 img 属性外的所有属性到 `<figure>`，图片保留这些属性。
    * - `(string | RegExp)[]`：**移动**仅匹配的属性到 `<figure>`，图片失去这些属性。
+   *
+   * 原生 img 属性（src、alt、title、width、height 等）永远不会被移动或复制到 `<figure>` 上。
    *
    * @example
    *   // Copy all non-native attrs to figure (img keeps them)

--- a/packages/plugin-figure/src/plugin.ts
+++ b/packages/plugin-figure/src/plugin.ts
@@ -19,6 +19,7 @@ const NATIVE_IMG_ATTRS = new Set([
   "sizes",
   "src",
   "srcset",
+  "title",
   "usemap",
   "width",
 ]);
@@ -112,6 +113,7 @@ export const figure: PluginWithOptions<MarkdownItFigureOptions> = (
 
           for (const attr of image.attrs) {
             if (
+              !NATIVE_IMG_ATTRS.has(attr[0]) &&
               moveAttrs.some((pattern) =>
                 typeof pattern === "string" ? pattern === attr[0] : pattern.test(attr[0]),
               )


### PR DESCRIPTION
## Summary

Fixes an issue in `plugin-figure` where `moveAttrs: true` copied the image's `title` onto `<figure title="...">`, causing the title to appear twice (on `<figure>` and in `<figcaption>`).

## Problem

`title` is part of the **native markdown image syntax** (like `src` and `alt`) — it is a native `<img>` attribute that `<figure>` does not support. With `moveAttrs: true` (which copies all non-native attrs), `title` was wrongly copied to `<figure>` while still being used as the `<figcaption>` content, producing a redundant title.

## Fix

`title` is now treated as a native img attribute (added to `NATIVE_IMG_ATTRS`), and the array `moveAttrs` path also skips native img attributes. Result:

- Native img attributes (`src`, `alt`, `title`, `width`, `height`, etc.) are **never** moved or copied to `<figure>`, regardless of configuration (`true` or an array that explicitly lists them / a RegExp matching them).
- `<figcaption>` always prefers the image's `title` (falling back to `alt`) — default behavior unchanged.
- Style-like attributes (`class`, `data-*`, ...) are still copied (`true`) or moved (array) to `<figure>` as before.

## Tests

- `packages/plugin-figure/__tests__/figure.spec.ts`: reworked the `moveAttrs` suite using a **test-only inline helper** (no extra package dependency) that injects a non-native attr onto image tokens, covering:
  - `class` copied (`true`) / moved (array) to `<figure>`; title stays as caption.
  - `title` never copied to `<figure>` with `true`.
  - `title` never moved even when explicitly listed (`["title"]`) or matched by a RegExp (`[/^tit/]`).
  - Other native attrs (`src`, `alt`) never moved when explicitly listed.
  - `data-*` still moved via RegExp patterns.
  - Linked images and empty-alt + title keep `title` as caption.
- `packages/plugin-attrs/__tests__/plugin.spec.ts`: added a combo test (attrs → figure `moveAttrs`) verifying a `class` added by `@mdit/plugin-attrs` is moved onto the `<figure>`.

No circular dependency: `plugin-figure` does not depend on `plugin-attrs`; the combo test lives in `plugin-attrs` (which already has `@mdit/plugin-figure` as a devDependency).

## Docs / JSDoc

- `options.ts` JSDoc now states that native img attributes are never moved/copied to `<figure>` (EN + ZH).
- `docs/src/figure.md` and `docs/src/zh/figure.md` updated accordingly.

## Verification

- `pnpm exec vitest run --coverage` (in `packages/plugin-figure`): **22/22 tests passing**, **100%** statements/branches/functions/lines.
- `pnpm exec vitest run --coverage` (in `packages/plugin-attrs`): **602/602 tests passing**, **100%**.
- `pnpm run lint:check`: clean.
- `pnpm run type-check`: clean.
