### PR TITLE
feat(plugin-attrs): add parseAttrs helper

### DIFF
--- a/docs/src/attrs.md
+++ b/docs/src/attrs.md
@@ -154,6 +154,27 @@ type MarkdownItAttrRuleName =
 - Default: `'}'`
 - Details: Right delimiter for attributes.
 
+## Programmatic Parsing
+
+The package exports a `parseAttrs` helper so that other tools (e.g.: shiki transformers) can reuse the attrs parsing logic:
+
+```ts
+import { parseAttrs } from "@mdit/plugin-attrs";
+
+parseAttrs("foo {.bar #baz data-a=b}");
+// [["class", "bar"], ["id", "baz"], ["data-a", "b"]]
+
+parseAttrs("foo"); // null
+```
+
+`parseAttrs(content, options)` returns the parsed attrs as `[key, value]` tuples, or `null` when no valid attrs section is found. A valid section yielding no attrs (e.g.: all filtered out by `allowed`) returns an empty array. Besides `left`, `right` and `allowed` which behave the same as the plugin options, an extra `where` option is supported:
+
+### where
+
+- Type: `"start" | "end" | "only"`
+- Default: `"end"`
+- Details: Where the attrs section shall be located in the content: at the start, at the end, or the content shall only contain the attrs section.
+
 ## Demo
 
 > All classes are styled with `margin: 4px;padding: 4px;border: 1px solid red;` to show the effect.

--- a/docs/src/zh/attrs.md
+++ b/docs/src/zh/attrs.md
@@ -152,6 +152,27 @@ type MarkdownItAttrRuleName =
 - 默认值：`'}'`
 - 详情：属性右分隔符。
 
+## 编程式解析
+
+包导出了 `parseAttrs` 工具函数，以便其他工具 (如 shiki transformer) 复用属性解析逻辑：
+
+```ts
+import { parseAttrs } from "@mdit/plugin-attrs";
+
+parseAttrs("foo {.bar #baz data-a=b}");
+// [["class", "bar"], ["id", "baz"], ["data-a", "b"]]
+
+parseAttrs("foo"); // null
+```
+
+`parseAttrs(content, options)` 返回解析出的 `[key, value]` 属性元组，未找到有效属性部分时返回 `null`。有效属性部分未解析出任何属性（如全部被 `allowed` 过滤）时返回空数组。除了与插件选项行为一致的 `left`、`right` 和 `allowed` 外，还支持额外的 `where` 选项：
+
+### where
+
+- 类型：`"start" | "end" | "only"`
+- 默认值：`"end"`
+- 详情：属性部分在内容中的位置：位于开头、位于结尾，或内容仅包含属性部分。
+
 ## 示例
 
 > 所有的 class 都使用 `margin: 4px;padding: 4px;border: 1px solid red;` 进行显示以展示效果。

--- a/packages/plugin-attrs/__tests__/parseAttrs.spec.ts
+++ b/packages/plugin-attrs/__tests__/parseAttrs.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from "vitest";
+
+import { parseAttrs } from "../src/index.js";
+
+describe(parseAttrs, () => {
+  it("should parse attrs at the end by default", () => {
+    expect(parseAttrs("foo {.bar #baz data-a=b}")).toStrictEqual([
+      ["class", "bar"],
+      ["id", "baz"],
+      ["data-a", "b"],
+    ]);
+
+    expect(parseAttrs("{.bar}")).toStrictEqual([["class", "bar"]]);
+  });
+
+  it("should return null when no valid attrs section is found", () => {
+    expect(parseAttrs("foo")).toBeNull();
+    expect(parseAttrs("")).toBeNull();
+    expect(parseAttrs("foo {.bar} baz")).toBeNull();
+  });
+
+  it("should support quoted values and css modules", () => {
+    expect(parseAttrs('foo {..module key="value with spaces"}')).toStrictEqual([
+      ["css-module", "module"],
+      ["key", "value with spaces"],
+    ]);
+  });
+
+  it("should return an empty array when the attrs section contains no attrs", () => {
+    expect(parseAttrs("foo { }")).toStrictEqual([]);
+  });
+
+  it("should support where option", () => {
+    expect(parseAttrs("{.bar} foo", { where: "start" })).toStrictEqual([["class", "bar"]]);
+    expect(parseAttrs("foo {.bar}", { where: "start" })).toBeNull();
+
+    expect(parseAttrs("{.bar}", { where: "only" })).toStrictEqual([["class", "bar"]]);
+    expect(parseAttrs("foo {.bar}", { where: "only" })).toBeNull();
+  });
+
+  it("should support custom delimiters", () => {
+    expect(parseAttrs("foo [.bar]", { left: "[", right: "]" })).toStrictEqual([["class", "bar"]]);
+    expect(parseAttrs("foo {.bar}", { left: "[", right: "]" })).toBeNull();
+  });
+
+  it("should filter attrs with allowed option", () => {
+    expect(parseAttrs("foo {.bar #baz data-a=b}", { allowed: ["class", "id"] })).toStrictEqual([
+      ["class", "bar"],
+      ["id", "baz"],
+    ]);
+
+    expect(parseAttrs("foo {.bar #baz}", { allowed: [{ name: "id" }] })).toStrictEqual([
+      ["id", "baz"],
+    ]);
+
+    expect(
+      parseAttrs("foo {a=1 b=2}", {
+        allowed: [
+          { name: "a", value: ["1"] },
+          { name: "b", value: ["3"] },
+        ],
+      }),
+    ).toStrictEqual([["a", "1"]]);
+
+    // a valid attrs section with all attrs filtered out yields [], not null
+    expect(parseAttrs("foo {.bar}", { allowed: ["id"] })).toStrictEqual([]);
+  });
+});

--- a/packages/plugin-attrs/src/index.ts
+++ b/packages/plugin-attrs/src/index.ts
@@ -1,2 +1,4 @@
+export type * from "./helper/types.js";
 export type * from "./options.js";
+export * from "./parseAttrs.js";
 export * from "./plugin.js";

--- a/packages/plugin-attrs/src/options.ts
+++ b/packages/plugin-attrs/src/options.ts
@@ -1,5 +1,24 @@
 import type { DelimiterConfig } from "./helper/index.js";
 
+export interface ParseAttrsOptions extends Partial<Omit<DelimiterConfig, "filter">> {
+  /**
+   * Where the attrs section shall be located in the content
+   *
+   * - `"start"`: at the start of the content
+   * - `"end"`: at the end of the content
+   * - `"only"`: the content shall only contain the attrs section
+   *
+   * 属性部分在内容中的位置
+   *
+   * - `"start"`: 位于内容开头
+   * - `"end"`: 位于内容结尾
+   * - `"only"`: 内容仅包含属性部分
+   *
+   * @default "end"
+   */
+  where?: "start" | "end" | "only";
+}
+
 export type MarkdownItAttrRuleName =
   | "fence"
   | "inline"

--- a/packages/plugin-attrs/src/parseAttrs.ts
+++ b/packages/plugin-attrs/src/parseAttrs.ts
@@ -8,10 +8,8 @@ import type { ParseAttrsOptions } from "./options.js";
  * 从包含分隔符属性部分的字符串中解析属性
  *
  * @example
- *   ```ts
  *   parseAttrs("foo {.bar #baz data-a=b}");
  *   // [["class", "bar"], ["id", "baz"], ["data-a", "b"]]
- *   ```;
  *
  * @param content - Content to parse / 要解析的内容
  * @param options - Parse options / 解析选项

--- a/packages/plugin-attrs/src/parseAttrs.ts
+++ b/packages/plugin-attrs/src/parseAttrs.ts
@@ -1,0 +1,29 @@
+import type { Attr } from "./helper/index.js";
+import { createDelimiterChecker, getAttrs, normalizeAllowed } from "./helper/index.js";
+import type { ParseAttrsOptions } from "./options.js";
+
+/**
+ * Parse attrs from a string containing a delimited attrs section
+ *
+ * 从包含分隔符属性部分的字符串中解析属性
+ *
+ * @example
+ *   ```ts
+ *   parseAttrs("foo {.bar #baz data-a=b}");
+ *   // [["class", "bar"], ["id", "baz"], ["data-a", "b"]]
+ *   ```;
+ *
+ * @param content - Content to parse / 要解析的内容
+ * @param options - Parse options / 解析选项
+ * @returns Parsed attrs, or `null` when no valid attrs section is found / 解析出的属性，未找到有效属性部分时为
+ * `null`
+ */
+export const parseAttrs = (
+  content: string,
+  { where = "end", left = "{", right = "}", allowed = [] }: ParseAttrsOptions = {},
+): Attr[] | null => {
+  const filter = normalizeAllowed(allowed);
+  const range = createDelimiterChecker({ left, right, allowed, filter }, where)(content);
+
+  return range === false ? null : getAttrs(content, range, filter);
+};

--- a/packages/plugin-attrs/src/rules/types.ts
+++ b/packages/plugin-attrs/src/rules/types.ts
@@ -98,7 +98,6 @@ export interface AttrRule {
  * Define an attribute rule helper
  *
  * @example
- *   ```ts
  *   const rule = defineAttrRule({
  *     name: "example",
  *     tests: [],
@@ -106,7 +105,6 @@ export interface AttrRule {
  *       // transform logic
  *     },
  *   });
- *   ```;
  *
  * @param rule - Attribute rule definition / 属性规则定义
  * @returns Attribute rule passed through without modification / 未被修改的属性规则

--- a/packages/plugin-inline-rule/src/options.ts
+++ b/packages/plugin-inline-rule/src/options.ts
@@ -10,12 +10,10 @@ interface InlineRuleBaseOptions {
    * 用作标记的标点符号字符
    *
    * @example
-   *   ```ts
    *   // Single character for sub/sup
    *   marker: "~";
    *   // Single character that gets doubled for spoiler
    *   marker: "!";
-   *   ```;
    */
   marker: string;
 
@@ -25,10 +23,8 @@ interface InlineRuleBaseOptions {
    * 渲染元素的 HTML 标签名称
    *
    * @example
-   *   ```ts
    *   tag: "sub";
    *   tag: "span";
-   *   ```;
    */
   tag: string;
 
@@ -38,10 +34,8 @@ interface InlineRuleBaseOptions {
    * 用于 markdown-it 令牌标识的令牌类型名称
    *
    * @example
-   *   ```ts
    *   token: "sub";
    *   token: "spoiler";
-   *   ```;
    */
   token: string;
 
@@ -51,12 +45,10 @@ interface InlineRuleBaseOptions {
    * 渲染元素的自定义 HTML 属性
    *
    * @example
-   *   ```ts
    *   attrs: [
    *     ["class", "spoiler"],
    *     ["tabindex", "-1"],
    *   ];
-   *   ```;
    *
    * @default undefined
    */
@@ -131,7 +123,6 @@ export interface NestedInlineRuleOptions extends InlineRuleBaseOptions {
  * 内联规则工厂插件的配置选项
  *
  * @example
- *   ```ts
  *   // Non-nested (linear scan) - for simple tags like sub/sup
  *   md.use(inlineRule, {
  *     marker: "^",
@@ -147,6 +138,5 @@ export interface NestedInlineRuleOptions extends InlineRuleBaseOptions {
  *     nested: true,
  *     placement: "before-emphasis",
  *   });
- *   ```;
  */
 export type InlineRuleOptions = NonNestedInlineRuleOptions | NestedInlineRuleOptions;


### PR DESCRIPTION
### Description

close #636

Exports a `parseAttrs` helper from `@mdit/plugin-attrs` for programmatic parsing of attrs sections, so external tools (e.g. shiki transformers in VitePress) can reuse the plugin's parsing logic:

```ts
import { parseAttrs } from "@mdit/plugin-attrs";

parseAttrs("foo {.bar #baz data-a=b}");
// [["class", "bar"], ["id", "baz"], ["data-a", "b"]]

parseAttrs("foo"); // null
```

- `ParseAttrsOptions` supports `where: "start" | "end" | "only"` (default `"end"`) plus the plugin's `left` / `right` / `allowed` options. It composes the existing internals (`createDelimiterChecker` + `normalizeAllowed` + `getAttrs`), so semantics match plugin behavior exactly.
- Compared with the sketch in #636, the internal `filter` field is deliberately omitted from the options: it is a value derived from `allowed` (the plugin itself ignores a user-provided `filter` and recomputes it), so exposing both would be confusing.
- The supporting types (`Attr`, `AllowedAttrs`, `AllowedAttrEntry`, `AttrFilter`, `DelimiterConfig`) are now exported from the package index since they appear in public signatures.
- Docs (en + zh) and tests added; package coverage stays at 100% statements / branches / functions / lines.

### Re: moving to `@mdit/helper` for plugin-icon reuse

> Btw, plugin-icon could reuse it's logic? (Not sure) If so this can be moved to helper package?

I looked into this and I don't think plugin-icon can realistically reuse it — its `extractAttrs` parses a fundamentally different grammar:

| | plugin-attrs (`parseAttrs`) | plugin-icon (`extractAttrs`) |
| --- | --- | --- |
| Model | parses an entire `{...}`-delimited section as attrs | extracts `key=value` pairs out of mixed content, remainder is the icon name |
| Delimiters | required (configurable) | none |
| Shorthands | `.class`, `..css-module`, `#id` | none (`.` / `#` / `:` are legal inside icon names, e.g. `mdi:home`) |
| Quotes | double quotes only, escapes kept as-is | single or double quotes, escaped quotes unescaped |
| Keys | any chars minus a small excluded set | strict `[A-Za-z_][a-zA-Z0-9_-]*` |
| Extra syntax | — | `=size` and `/color` shorthands |
| Output | ordered `[key, value]` tuples (duplicates allowed, e.g. classes) | `Record<string, string>` + cleaned content |

A shared parser would need a mode for every one of those rows, ending up more complex and slower than either dedicated parser, and any syntax convergence would be a breaking change for plugin-icon users. Since `@mdit/helper` currently holds small generic utilities, moving an attrs-specific subsystem there without a second consumer would mainly couple helper's release cadence to plugin-attrs internals — so this PR keeps the parser in `plugin-attrs`. If a second consumer shows up later, moving it to `@mdit/helper` and re-exporting from `plugin-attrs` would be a non-breaking follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)