### PR TITLE
feat(plugin-anchor)!: rewrite default slugify

### DIFF
--- a/docs/src/anchor.md
+++ b/docs/src/anchor.md
@@ -25,7 +25,12 @@ import MarkdownIt from "markdown-it";
 import { anchor } from "@mdit/plugin-anchor";
 
 const mdIt = MarkdownIt().use(anchor, {
-  slugify: (s) => encodeURIComponent(s.trim().toLowerCase().replace(/\s+/g, "-")),
+  slugify: (s) =>
+    s
+      .trim()
+      .toLowerCase()
+      .replace(/[^\w\u4e00-\u9fff-]+/g, "-")
+      .replace(/-+/g, "-"),
 });
 
 mdIt.render("# Hello World");
@@ -61,6 +66,15 @@ Consectetur adipiscing elit.
 
 - Type: `(str: string) => string`
 - Details: Custom slugification function to transform heading text to URL-friendly slugs.
+
+By default it lowercases ASCII letters, keeps non-ASCII characters (e.g. CJK), folds whitespace and dashes into a single dash, and strips other ASCII punctuation. If you want strictly percent-encoded slugs instead, use the exported `legacySlugify`:
+
+```ts
+import MarkdownIt from "markdown-it";
+import { anchor, legacySlugify } from "@mdit/plugin-anchor";
+
+const mdIt = MarkdownIt().use(anchor, { slugify: legacySlugify });
+```
 
 ### slugifyWithState
 

--- a/docs/src/zh/anchor.md
+++ b/docs/src/zh/anchor.md
@@ -25,7 +25,12 @@ import MarkdownIt from "markdown-it";
 import { anchor } from "@mdit/plugin-anchor";
 
 const mdIt = MarkdownIt().use(anchor, {
-  slugify: (s) => encodeURIComponent(s.trim().toLowerCase().replace(/\s+/g, "-")),
+  slugify: (s) =>
+    s
+      .trim()
+      .toLowerCase()
+      .replace(/[^\w\u4e00-\u9fff-]+/g, "-")
+      .replace(/-+/g, "-"),
 });
 
 mdIt.render("# 你好 世界");
@@ -61,6 +66,15 @@ mdIt.render("# 你好 世界");
 
 - 类型：`(str: string) => string`
 - 详情：自定义 slug 化函数，将标题文本转换为 URL 友好的 slug。
+
+默认会转小写 ASCII 字母、保留非 ASCII 字符（如中文）、将空白与连字符折叠为单个连字符，并剥离其余 ASCII 标点。如果你想要严格百分号编码的 slug，可使用导出的 `legacySlugify`：
+
+```ts
+import MarkdownIt from "markdown-it";
+import { anchor, legacySlugify } from "@mdit/plugin-anchor";
+
+const mdIt = MarkdownIt().use(anchor, { slugify: legacySlugify });
+```
 
 ### slugifyWithState
 

--- a/packages/plugin-anchor/__tests__/basic.spec.ts
+++ b/packages/plugin-anchor/__tests__/basic.spec.ts
@@ -2,6 +2,7 @@ import { attrs } from "@mdit/plugin-attrs";
 import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
+import { legacySlugify } from "../src/defaults.js";
 import type { AnchorOptions } from "../src/options.js";
 import type { PermalinkGenerator } from "../src/permalink/types.js";
 import { anchor } from "../src/plugin.js";
@@ -62,6 +63,46 @@ describe("slug options", () => {
     expect(md().render("#### `options`")).toBe(
       '<h4 id="options" tabindex="-1"><code>options</code></h4>\n',
     );
+  });
+
+  it("should slugify punctuation without percent-encoding", () => {
+    expect(md().render("# Hello, World! (C++)")).toBe(
+      '<h1 id="hello-world-c" tabindex="-1">Hello, World! (C++)</h1>\n',
+    );
+  });
+
+  it("should keep CJK in slug", () => {
+    expect(md().render("# 中文标题")).toBe('<h1 id="中文标题" tabindex="-1">中文标题</h1>\n');
+  });
+
+  it("should collapse consecutive dashes in slug", () => {
+    expect(md().render("# foo---bar")).toBe('<h1 id="foo-bar" tabindex="-1">foo---bar</h1>\n');
+  });
+
+  it("should trim trailing dashes in slug", () => {
+    expect(md().render("# Hello -")).toBe('<h1 id="hello" tabindex="-1">Hello -</h1>\n');
+  });
+
+  it("should trim leading dashes in slug", () => {
+    expect(md().render("# - foo")).toBe('<h1 id="foo" tabindex="-1">- foo</h1>\n');
+  });
+
+  it("should fold nbsp into a dash in slug", () => {
+    expect(md().render("# foo\u00A0bar")).toBe(
+      '<h1 id="foo-bar" tabindex="-1">foo\u00A0bar</h1>\n',
+    );
+  });
+
+  it("should percent-encode punctuation with legacySlugify", () => {
+    expect(legacySlugify("Hello, World! (C++)")).toBe("hello%2C-world!-(c%2B%2B)");
+  });
+
+  it("should percent-encode CJK with legacySlugify", () => {
+    expect(legacySlugify("中文标题")).toBe("%E4%B8%AD%E6%96%87%E6%A0%87%E9%A2%98");
+  });
+
+  it("should keep dash runs with legacySlugify", () => {
+    expect(legacySlugify("foo---bar")).toBe("foo---bar");
   });
 
   it("should support custom slugify", () => {

--- a/packages/plugin-anchor/src/defaults.ts
+++ b/packages/plugin-anchor/src/defaults.ts
@@ -9,7 +9,64 @@ export const defaultGetTokensText = (tokens: Token[]): string =>
     .map((token) => token.content)
     .join("");
 
-export const defaultSlugify = (str: string): string =>
+/**
+ * Default slugify function: lowercase, keep ASCII alphanumeric / underscore / non-ASCII (CJK etc.),
+ * fold whitespace (including nbsp) and dashes into a single dash, and strip other ASCII
+ * punctuation.
+ *
+ * 默认 slug 生成函数：转小写、保留 ASCII 字母数字 / 下划线 / 非 ASCII（如中文）、 将空白（含 nbsp）与连字符折叠为单个连字符、剥离其余 ASCII 标点。
+ *
+ * @param str - The string to slugify / 要生成 slug 的字符串
+ * @returns The slugified string / 生成的 slug
+ */
+export const defaultSlugify = (str: string): string => {
+  let result = "";
+  let prevDash = false;
+
+  for (let i = 0; i < str.length; i++) {
+    const code = str.charCodeAt(i);
+
+    if (
+      (code >= 48 && code <= 57) || // 0-9
+      (code >= 97 && code <= 122) || // a-z
+      (code >= 65 && code <= 90) || // A-Z
+      code === 95 // _
+    ) {
+      result += code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : str[i];
+      prevDash = false;
+    } else if (code === 32 || code === 9 || code === 45 || code === 160) {
+      // whitespace (space, tab, nbsp) or a dash -> a single dash separator
+      if (!prevDash && result.length > 0) {
+        result += "-";
+        prevDash = true;
+      }
+    } else if (code >= 128) {
+      // non-ASCII (CJK etc.) is kept
+      result += str[i];
+      prevDash = false;
+    }
+    // other punctuation is stripped
+  }
+
+  // remove a possible trailing dash
+  if (result.charCodeAt(result.length - 1) === 45 /* - */) result = result.slice(0, -1);
+
+  return result;
+};
+
+/**
+ * Legacy slugify: percent-encode based, keeps the previous default behavior for maximum
+ * compatibility with tools that expect ASCII-only fragments.
+ *
+ * 旧版 slug 生成函数：基于百分号编码，保留此前的默认行为，以兼容期望纯 ASCII fragment 的工具。
+ *
+ * Forked and modified from
+ * https://github.com/valeriangalliat/markdown-it-anchor/blob/master/index.mjs
+ *
+ * @param str - The string to slugify / 要生成 slug 的字符串
+ * @returns The slugified string / 生成的 slug
+ */
+export const legacySlugify = (str: string): string =>
   encodeURIComponent(str.trim().toLowerCase().replaceAll(/\s+/g, "-"));
 
 export const permalinkDefaults: PermalinkOptions = {

--- a/packages/plugin-anchor/src/index.ts
+++ b/packages/plugin-anchor/src/index.ts
@@ -1,4 +1,5 @@
 export type * from "./options.js";
 export { anchor } from "./plugin.js";
+export { legacySlugify } from "./defaults.js";
 export * from "./permalink/index.js";
 export { renderAttrs, renderHref } from "./utils.js";


### PR DESCRIPTION
### Summary

Rewrite the default slugify. This is a **breaking change**.

### Breaking change

The default slug now keeps non-ASCII characters (e.g. CJK) instead of
percent-encoding them:

- `# 中文标题` -> `id="中文标题"` (was `id="%E4%B8%AD%E6%96%87%E6%A0%87%E9%A2%98"`)
- `# Hello, World! (C++)` -> `id="hello-world-c"` (was `id="hello%2C-world!-(c%2B%2B)"`)

The new default lowercases ASCII letters, keeps non-ASCII characters, folds
whitespace (including nbsp) and dashes into a single dash, strips other ASCII
punctuation, and trims leading/trailing dashes.

### Migration

To keep the previous percent-encoded behavior, use the newly exported
`legacySlugify`:

```ts
import MarkdownIt from "markdown-it";
import { anchor, legacySlugify } from "@mdit/plugin-anchor";

const mdIt = MarkdownIt().use(anchor, { slugify: legacySlugify });
```

### Tests

- New default slug cases: punctuation stripping, CJK retention, dash
  collapsing, leading/trailing dash trimming, nbsp folding.
- `legacySlugify` unit tests preserving the previous behavior (percent-encoded
  punctuation and CJK, kept dash runs).

Coverage stays at 100%.

### Docs

- Documented the new default slugify behavior and the `legacySlugify`
  migration in both English and Chinese docs.
