### PR TITLE
perf(plugin-anchor): skip redundant indexOf scan

### DIFF
--- a/packages/plugin-anchor/__tests__/basic.spec.ts
+++ b/packages/plugin-anchor/__tests__/basic.spec.ts
@@ -1,6 +1,6 @@
 import { attrs } from "@mdit/plugin-attrs";
 import MarkdownIt from "markdown-it";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { legacySlugify } from "../src/defaults.js";
 import type { AnchorOptions } from "../src/options.js";
@@ -266,5 +266,32 @@ describe("legacy options", () => {
     expect(md(legacyOptions as AnchorOptions).render("# H1")).toBe(
       '<h1 id="h1" tabindex="-1">H1</h1>\n',
     );
+  });
+});
+
+describe("performance", () => {
+  it("should not scan the tokens array without a permalink", () => {
+    const src = "# H1\n\n## H2\n\n### H3\n\npara text here";
+
+    const countIndexOf = (instance: MarkdownIt): number => {
+      const spy = vi.spyOn(Array.prototype, "indexOf");
+
+      instance.render(src);
+
+      const count = spy.mock.calls.length;
+
+      spy.mockRestore();
+
+      return count;
+    };
+
+    const plainCount = countIndexOf(MarkdownIt({ html: true }));
+    const noPermalinkCount = countIndexOf(md());
+    const withPermalinkCount = countIndexOf(md({ permalink: (): void => {} }));
+
+    // The anchor rule itself must not scan the tokens array without a permalink,
+    // and should do exactly one scan per selected heading when a permalink is set.
+    expect(noPermalinkCount).toBe(plainCount);
+    expect(withPermalinkCount).toBe(plainCount + 3);
   });
 });

--- a/packages/plugin-anchor/src/plugin.ts
+++ b/packages/plugin-anchor/src/plugin.ts
@@ -61,11 +61,13 @@ export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void
 
       if (tabIndex !== false) token.attrSet("tabindex", `${tabIndex}`);
 
-      if (typeof permalink === "function") permalink(slug, resolvedOptions, state, index);
+      if (typeof permalink === "function") {
+        permalink(slug, resolvedOptions, state, index);
 
-      // A permalink renderer could modify the `tokens` array so
-      // make sure to get the up-to-date index on each iteration.
-      index = tokens.indexOf(token);
+        // A permalink renderer could modify the `tokens` array so
+        // make sure to get the up-to-date index on each iteration.
+        index = tokens.indexOf(token);
+      }
 
       // oxlint-disable-next-line promise/prefer-await-to-callbacks
       if (callback) callback(token, { slug, title });


### PR DESCRIPTION
### Summary

Avoid a redundant `Array.prototype.indexOf` scan per heading in the `plugin-anchor` core rule when no permalink is configured.

### Problem

The anchor core rule unconditionally recomputed the loop index with:

```ts
index = tokens.indexOf(token);
```

for every selected heading, regardless of whether a permalink is present. This made rendering cost O(headings × tokens) even though the recomputation is only needed when a permalink generator is configured (a permalink renderer may insert/reorder tokens, so the loop index must be re-synced).

### Change

Move the `tokens.indexOf` recomputation inside the `permalink` branch, so it only runs when a permalink function is set:

```ts
if (typeof permalink === "function") {
  permalink(slug, resolvedOptions, state, index);
  index = tokens.indexOf(token);
}
```

`callback` is intentionally not part of the guard: its signature `(token, { slug, title })` gives it no access to `state`/the tokens array, so it cannot modify the array and does not need an index resync.

### Behavior

No output changes. With a permalink, each selected heading still recomputes the index exactly once (keeping the loop correct after token insertion). Without a permalink, the redundant scan is skipped.

### Tests

- Added a performance regression test that counts `Array.prototype.indexOf` calls during render:
  - Without a permalink, the anchor rule contributes `0` calls (same count as plain markdown-it).
  - With a permalink, exactly one extra call per selected heading.
- All 73 tests pass; coverage stays at 100% (statements/branches/functions/lines).
