### PR TITLE
fix(plugin-mathjax): reset state after each render

### DIFF
--- a/docs/src/mathjax.md
+++ b/docs/src/mathjax.md
@@ -105,9 +105,10 @@ interface MarkdownItMathjaxOptions {
 
 The instance holds render content of each calls, so you should:
 
-- Call `mathjaxInstance.reset()` before each render in different pages, this ensure things like label are reset.
 - Call `mathjaxInstance.outputStyle()` after all rendering is done, to get final CSS content.
 - Call `mathjaxInstance.clearStyle()` to clear existing style cache if necessary.
+
+The plugin automatically calls `mathjaxInstance.reset()` after each render, clearing user-defined macros, environments and labels so that state does not leak across documents. To keep macros available in every document, define them with the `tex.macros` option instead.
 
 We also have a package called `@mdit/plugin-mathjax-slim`, for which `@mathjax/src` and `@mathjax/mathjax-newcm-font` are optional peer deps.
 

--- a/docs/src/zh/mathjax.md
+++ b/docs/src/zh/mathjax.md
@@ -105,9 +105,10 @@ interface MarkdownItMathjaxOptions {
 
 该实例包含每个调用的渲染内容，因此你应该：
 
-- 在不同页面中的每次渲染之前调用 `mathjaxInstance.reset()`，这确保标签之类的项目被重置。
 - 在所有渲染完成后调用 `mathjaxInstance.outputStyle()`，以获得最终的 CSS 内容。
 - 如有必要，调用 `mathjaxInstance.clearStyle()` 清除现有样式缓存。
+
+插件会在每次渲染后自动调用 `mathjaxInstance.reset()`，清除用户定义的宏、环境与标签，避免状态跨文档泄漏。如需在所有文档中持续使用某个宏，请改用 `tex.macros` 选项定义。
 
 我们也有一个 `@mdit/plugin-mathjax-slim` 包，其中 `@mathjax/src` 和 `@mathjax/mathjax-newcm-font` 是可选对等依赖。
 

--- a/packages/plugin-mathjax-slim/__tests__/html-sync.spec.ts
+++ b/packages/plugin-mathjax-slim/__tests__/html-sync.spec.ts
@@ -140,7 +140,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax-slim/__tests__/html.spec.ts
+++ b/packages/plugin-mathjax-slim/__tests__/html.spec.ts
@@ -140,7 +140,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = await mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax-slim/__tests__/state.spec.ts
+++ b/packages/plugin-mathjax-slim/__tests__/state.spec.ts
@@ -1,0 +1,104 @@
+import MarkdownIt from "markdown-it";
+import { describe, expect, it, vi } from "vitest";
+
+import { createMathjaxInstance, mathjax as mathjaxAsync } from "../src/index.js";
+import {
+  createMathjaxInstance as createSyncInstance,
+  mathjax as mathjaxSync,
+} from "../src/sync.js";
+
+// The SVG output contains an incrementing id counter (e.g. `MJX-1`, `MJX-3`)
+// shared by the output jax, so normalize it away before comparing renders.
+const normalize = (html: string): string => html.replaceAll(/MJX-\d+/g, "MJX-N");
+
+describe("mathjax-slim state isolation", () => {
+  describe("async", () => {
+    it("should reset state after render and renderInline", async () => {
+      const instance = (await createMathjaxInstance())!;
+      const resetSpy = vi.spyOn(instance, "reset");
+      const md = MarkdownIt({ html: true }).use(mathjaxAsync, instance);
+
+      md.render("$x$");
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+
+      md.renderInline("$y$");
+      expect(resetSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not leak newcommand macros across documents", async () => {
+      const instance = (await createMathjaxInstance())!;
+      const md = MarkdownIt({ html: true }).use(mathjaxAsync, instance);
+
+      // Doc 1 defines the macro
+      md.render(String.raw`$\newcommand{\foo}{bar}\foo$`);
+
+      // Doc 2 must not see the macro defined in Doc 1
+      const doc2 = md.render(String.raw`$\foo$`);
+
+      const freshInstance = (await createMathjaxInstance())!;
+      const freshMd = MarkdownIt({ html: true }).use(mathjaxAsync, freshInstance);
+      const baseline = freshMd.render(String.raw`$\foo$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+
+    it("should not leak newenvironment macros across documents", async () => {
+      const instance = (await createMathjaxInstance())!;
+      const md = MarkdownIt({ html: true }).use(mathjaxAsync, instance);
+
+      // Doc 1 defines the environment
+      md.render(String.raw`$$\newenvironment{foo}{[}{]}\begin{foo}x\end{foo}$$`);
+
+      // Doc 2 must not see the environment defined in Doc 1
+      const doc2 = md.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      const freshInstance = (await createMathjaxInstance())!;
+      const freshMd = MarkdownIt({ html: true }).use(mathjaxAsync, freshInstance);
+      const baseline = freshMd.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+  });
+
+  describe("sync", () => {
+    it("should reset state after render and renderInline", () => {
+      const instance = createSyncInstance()!;
+      const resetSpy = vi.spyOn(instance, "reset");
+      const md = MarkdownIt({ html: true }).use(mathjaxSync, instance);
+
+      md.render("$x$");
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+
+      md.renderInline("$y$");
+      expect(resetSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not leak newcommand macros across documents", () => {
+      const instance = createSyncInstance()!;
+      const md = MarkdownIt({ html: true }).use(mathjaxSync, instance);
+
+      md.render(String.raw`$\newcommand{\foo}{bar}\foo$`);
+      const doc2 = md.render(String.raw`$\foo$`);
+
+      const freshInstance = createSyncInstance()!;
+      const freshMd = MarkdownIt({ html: true }).use(mathjaxSync, freshInstance);
+      const baseline = freshMd.render(String.raw`$\foo$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+
+    it("should not leak newenvironment macros across documents", () => {
+      const instance = createSyncInstance()!;
+      const md = MarkdownIt({ html: true }).use(mathjaxSync, instance);
+
+      md.render(String.raw`$$\newenvironment{foo}{[}{]}\begin{foo}x\end{foo}$$`);
+      const doc2 = md.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      const freshInstance = createSyncInstance()!;
+      const freshMd = MarkdownIt({ html: true }).use(mathjaxSync, freshInstance);
+      const baseline = freshMd.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+  });
+});

--- a/packages/plugin-mathjax-slim/__tests__/svg-sync.spec.ts
+++ b/packages/plugin-mathjax-slim/__tests__/svg-sync.spec.ts
@@ -136,7 +136,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax-slim/__tests__/svg.spec.ts
+++ b/packages/plugin-mathjax-slim/__tests__/svg.spec.ts
@@ -136,7 +136,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = await mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax-slim/src/plugin.ts
+++ b/packages/plugin-mathjax-slim/src/plugin.ts
@@ -18,6 +18,7 @@ import type MarkdownIt from "markdown-it";
 
 import type { MarkdownItMathjaxOptions, DocumentOptions, MathjaxInstance } from "./options.js";
 import { loadTexPackages, texPackages } from "./tex/index.js";
+import { clearUserState } from "./utils.js";
 
 let isMathJaxInstalled = true;
 let mathjaxLib: typeof mathjaxType;
@@ -126,6 +127,7 @@ export const createMathjaxInstance = async (
 
   const reset = (): void => {
     InputJax.reset();
+    clearUserState(InputJax);
   };
 
   const outputStyle = async (): Promise<string> => {
@@ -163,9 +165,30 @@ export const mathjax = (
     delimiters,
     documentOptions,
     mathFence,
+    reset,
     transformer,
   }: MathjaxInstance,
 ): void => {
+  // Reset the shared TeX input state (macros/labels) after each render so that
+  // state does not leak across documents rendered by the same instance.
+  const render = md.render.bind(md);
+  const renderInline = md.renderInline.bind(md);
+
+  md.render = (src, env): string => {
+    try {
+      return render(src, env);
+    } finally {
+      reset();
+    }
+  };
+  md.renderInline = (src, env): string => {
+    try {
+      return renderInline(src, env);
+    } finally {
+      reset();
+    }
+  };
+
   md.use(tex, {
     allowInlineWithSpace,
     delimiters,

--- a/packages/plugin-mathjax-slim/src/sync.ts
+++ b/packages/plugin-mathjax-slim/src/sync.ts
@@ -20,6 +20,7 @@ import type MarkdownIt from "markdown-it";
 
 import type { MarkdownItMathjaxOptions, DocumentOptions, MathjaxInstance } from "./options.js";
 import { texPackages } from "./tex/index.js";
+import { clearUserState } from "./utils.js";
 
 let isMathJaxInstalled = true;
 let mathjaxLib: typeof mathjaxType;
@@ -166,6 +167,7 @@ export const createMathjaxInstance = (
 
   const reset = (): void => {
     InputJax.reset();
+    clearUserState(InputJax);
   };
 
   const outputStyle = (): string => {
@@ -203,9 +205,30 @@ export const mathjax = (
     delimiters,
     documentOptions,
     mathFence,
+    reset,
     transformer,
   }: MathjaxInstance,
 ): void => {
+  // Reset the shared TeX input state (macros/labels) after each render so that
+  // state does not leak across documents rendered by the same instance.
+  const render = md.render.bind(md);
+  const renderInline = md.renderInline.bind(md);
+
+  md.render = (src, env): string => {
+    try {
+      return render(src, env);
+    } finally {
+      reset();
+    }
+  };
+  md.renderInline = (src, env): string => {
+    try {
+      return renderInline(src, env);
+    } finally {
+      reset();
+    }
+  };
+
   md.use(tex, {
     allowInlineWithSpace,
     delimiters,

--- a/packages/plugin-mathjax-slim/src/utils.ts
+++ b/packages/plugin-mathjax-slim/src/utils.ts
@@ -1,0 +1,37 @@
+import type { LiteElement } from "@mathjax/src/js/adaptors/lite/Element.js";
+import type { TeX } from "@mathjax/src/js/input/tex.js";
+import { HandlerType } from "@mathjax/src/js/input/tex/HandlerTypes.js";
+
+interface TeXMacroMap {
+  map: Map<string, unknown>;
+}
+
+const USER_MAPS: { handler: HandlerType; name: string }[] = [
+  { handler: HandlerType.MACRO, name: "new-Command" },
+  { handler: HandlerType.ENVIRONMENT, name: "new-Environment" },
+  { handler: HandlerType.DELIMITER, name: "new-Delimiter" },
+];
+
+/**
+ * Clear user-defined TeX state (macros/environments/delimiters) on a MathJax TeX input jax.
+ *
+ * MathJax stores user-defined macros, environments and delimiters in dedicated `new-*` maps that
+ * are separate from the built-in maps, and `InputJax.reset()` does not clear them, so they would
+ * leak across documents rendered by the same instance. This reaches into the internal maps to
+ * remove only user-defined entries.
+ *
+ * 清除 MathJax TeX 输入 jax 上由 `\newcommand`/`\def`/`\newenvironment` 等定义的用户状态。
+ *
+ * MathJax 将用户自定义的宏、环境与分隔符存放在独立的 `new-*` 映射中，与内置映射分离，且 `InputJax.reset()`
+ * 不会清除它们，因此同一实例渲染多篇文档时状态会跨文档泄漏。此处直接访问内部映射，仅移除用户自定义条目。
+ *
+ * @param InputJax - MathJax TeX input jax / MathJax TeX 输入 jax
+ */
+export const clearUserState = (InputJax: TeX<LiteElement, string, HTMLElement>): void => {
+  for (const { handler, name } of USER_MAPS) {
+    const handlerMap = InputJax.parseOptions.handlers.get(handler);
+    const userMap = handlerMap.retrieve(name) as unknown as TeXMacroMap | null;
+
+    userMap?.map.clear();
+  }
+};

--- a/packages/plugin-mathjax/__tests__/html-sync.spec.ts
+++ b/packages/plugin-mathjax/__tests__/html-sync.spec.ts
@@ -140,7 +140,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax/__tests__/html.spec.ts
+++ b/packages/plugin-mathjax/__tests__/html.spec.ts
@@ -140,7 +140,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = await mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax/__tests__/state.spec.ts
+++ b/packages/plugin-mathjax/__tests__/state.spec.ts
@@ -1,0 +1,108 @@
+import MarkdownIt from "markdown-it";
+import { describe, expect, it, vi } from "vitest";
+
+import { createMathjaxInstance, mathjax as mathjaxAsync } from "../src/index.js";
+import {
+  createMathjaxInstance as createSyncInstance,
+  mathjax as mathjaxSync,
+} from "../src/sync.js";
+
+const setupAsync = async (): Promise<{ md: MarkdownIt }> => {
+  const instance = await createMathjaxInstance({ output: "svg", a11y: false });
+
+  return { md: MarkdownIt({ html: true }).use(mathjaxAsync, instance) };
+};
+
+const setupSync = (): { md: MarkdownIt } => {
+  const instance = createSyncInstance({ output: "svg", a11y: false })!;
+
+  return { md: MarkdownIt({ html: true }).use(mathjaxSync, instance) };
+};
+
+// The SVG output contains an incrementing id counter (e.g. `MJX-1`, `MJX-3`)
+// shared by the output jax, so normalize it away before comparing renders.
+const normalize = (html: string): string => html.replaceAll(/MJX-\d+/g, "MJX-N");
+
+describe("mathjax state isolation", () => {
+  describe("async", () => {
+    it("should reset state after render and renderInline", async () => {
+      const instance = (await createMathjaxInstance({ output: "svg", a11y: false }))!;
+      const resetSpy = vi.spyOn(instance, "reset");
+      const md = MarkdownIt({ html: true }).use(mathjaxAsync, instance);
+
+      md.render("$x$");
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+
+      md.renderInline("$y$");
+      expect(resetSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not leak newcommand macros across documents", async () => {
+      const { md } = await setupAsync();
+
+      // Doc 1 defines the macro
+      md.render(String.raw`$\newcommand{\foo}{bar}\foo$`);
+
+      // Doc 2 must not see the macro defined in Doc 1
+      const doc2 = md.render(String.raw`$\foo$`);
+
+      const { md: freshMd } = await setupAsync();
+      const baseline = freshMd.render(String.raw`$\foo$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+
+    it("should not leak newenvironment macros across documents", async () => {
+      const { md } = await setupAsync();
+
+      // Doc 1 defines the environment
+      md.render(String.raw`$$\newenvironment{foo}{[}{]}\begin{foo}x\end{foo}$$`);
+
+      // Doc 2 must not see the environment defined in Doc 1
+      const doc2 = md.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      const { md: freshMd } = await setupAsync();
+      const baseline = freshMd.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+  });
+
+  describe("sync", () => {
+    it("should reset state after render and renderInline", () => {
+      const instance = createSyncInstance({ output: "svg", a11y: false })!;
+      const resetSpy = vi.spyOn(instance, "reset");
+      const md = MarkdownIt({ html: true }).use(mathjaxSync, instance);
+
+      md.render("$x$");
+      expect(resetSpy).toHaveBeenCalledTimes(1);
+
+      md.renderInline("$y$");
+      expect(resetSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should not leak newcommand macros across documents", () => {
+      const { md } = setupSync();
+
+      md.render(String.raw`$\newcommand{\foo}{bar}\foo$`);
+      const doc2 = md.render(String.raw`$\foo$`);
+
+      const { md: freshMd } = setupSync();
+      const baseline = freshMd.render(String.raw`$\foo$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+
+    it("should not leak newenvironment macros across documents", () => {
+      const { md } = setupSync();
+
+      md.render(String.raw`$$\newenvironment{foo}{[}{]}\begin{foo}x\end{foo}$$`);
+      const doc2 = md.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      const { md: freshMd } = setupSync();
+      const baseline = freshMd.render(String.raw`$$\begin{foo}x\end{foo}$$`);
+
+      expect(normalize(doc2)).toBe(normalize(baseline));
+    });
+  });
+});

--- a/packages/plugin-mathjax/__tests__/svg-sync.spec.ts
+++ b/packages/plugin-mathjax/__tests__/svg-sync.spec.ts
@@ -136,7 +136,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax/__tests__/svg.spec.ts
+++ b/packages/plugin-mathjax/__tests__/svg.spec.ts
@@ -136,7 +136,9 @@ $$
       const markdownIt = MarkdownIt({ linkify: true }).use(mathjax, mathjaxInstance);
 
       expect(markdownIt.render(source)).not.toMatch(/mjx-error/);
-      expect(markdownIt.render(source)).toMatch(/mjx-error/);
+      // State is reset after each render, so the duplicate label is only
+      // detected when both definitions appear within the same document.
+      expect(markdownIt.render(`${source}\n\n${source}`)).toMatch(/mjx-error/);
 
       const style = await mathjaxInstance.outputStyle();
 

--- a/packages/plugin-mathjax/src/plugin.ts
+++ b/packages/plugin-mathjax/src/plugin.ts
@@ -18,6 +18,7 @@ import type MarkdownIt from "markdown-it";
 
 import type { DocumentOptions, MarkdownItMathjaxOptions, MathjaxInstance } from "./options.js";
 import { loadTexPackages, texPackages } from "./tex/index.js";
+import { clearUserState } from "./utils.js";
 
 export const getDocumentOptions = async (
   options: MarkdownItMathjaxOptions,
@@ -83,6 +84,7 @@ export const createMathjaxInstance = async (
 
   const reset = (): void => {
     InputJax.reset();
+    clearUserState(InputJax);
   };
 
   const outputStyle = async (): Promise<string> => {
@@ -120,9 +122,30 @@ export const mathjax = (
     delimiters,
     documentOptions,
     mathFence,
+    reset,
     transformer,
   }: MathjaxInstance,
 ): void => {
+  // Reset the shared TeX input state (macros/labels) after each render so that
+  // state does not leak across documents rendered by the same instance.
+  const render = md.render.bind(md);
+  const renderInline = md.renderInline.bind(md);
+
+  md.render = (src, env): string => {
+    try {
+      return render(src, env);
+    } finally {
+      reset();
+    }
+  };
+  md.renderInline = (src, env): string => {
+    try {
+      return renderInline(src, env);
+    } finally {
+      reset();
+    }
+  };
+
   md.use(tex, {
     allowInlineWithSpace,
     delimiters,

--- a/packages/plugin-mathjax/src/sync.ts
+++ b/packages/plugin-mathjax/src/sync.ts
@@ -21,6 +21,7 @@ import type MarkdownIt from "markdown-it";
 
 import type { MathjaxInstance, DocumentOptions, MarkdownItMathjaxOptions } from "./options.js";
 import { texPackages } from "./tex/index.js";
+import { clearUserState } from "./utils.js";
 
 import "@mathjax/src/js/input/tex/action/ActionConfiguration.js";
 import "@mathjax/src/js/input/tex/ams/AmsConfiguration.js";
@@ -124,6 +125,7 @@ export const createMathjaxInstance = (
 
   const reset = (): void => {
     InputJax.reset();
+    clearUserState(InputJax);
   };
 
   const outputStyle = (): string => {
@@ -161,9 +163,30 @@ export const mathjax = (
     delimiters,
     documentOptions,
     mathFence,
+    reset,
     transformer,
   }: MathjaxInstance,
 ): void => {
+  // Reset the shared TeX input state (macros/labels) after each render so that
+  // state does not leak across documents rendered by the same instance.
+  const render = md.render.bind(md);
+  const renderInline = md.renderInline.bind(md);
+
+  md.render = (src, env): string => {
+    try {
+      return render(src, env);
+    } finally {
+      reset();
+    }
+  };
+  md.renderInline = (src, env): string => {
+    try {
+      return renderInline(src, env);
+    } finally {
+      reset();
+    }
+  };
+
   md.use(tex, {
     allowInlineWithSpace,
     delimiters,

--- a/packages/plugin-mathjax/src/utils.ts
+++ b/packages/plugin-mathjax/src/utils.ts
@@ -1,0 +1,37 @@
+import type { LiteElement } from "@mathjax/src/js/adaptors/lite/Element.js";
+import type { TeX } from "@mathjax/src/js/input/tex.js";
+import { HandlerType } from "@mathjax/src/js/input/tex/HandlerTypes.js";
+
+interface TeXMacroMap {
+  map: Map<string, unknown>;
+}
+
+const USER_MAPS: { handler: HandlerType; name: string }[] = [
+  { handler: HandlerType.MACRO, name: "new-Command" },
+  { handler: HandlerType.ENVIRONMENT, name: "new-Environment" },
+  { handler: HandlerType.DELIMITER, name: "new-Delimiter" },
+];
+
+/**
+ * Clear user-defined TeX state (macros/environments/delimiters) on a MathJax TeX input jax.
+ *
+ * MathJax stores user-defined macros, environments and delimiters in dedicated `new-*` maps that
+ * are separate from the built-in maps, and `InputJax.reset()` does not clear them, so they would
+ * leak across documents rendered by the same instance. This reaches into the internal maps to
+ * remove only user-defined entries.
+ *
+ * 清除 MathJax TeX 输入 jax 上由 `\newcommand`/`\def`/`\newenvironment` 等定义的用户状态。
+ *
+ * MathJax 将用户自定义的宏、环境与分隔符存放在独立的 `new-*` 映射中，与内置映射分离，且 `InputJax.reset()`
+ * 不会清除它们，因此同一实例渲染多篇文档时状态会跨文档泄漏。此处直接访问内部映射，仅移除用户自定义条目。
+ *
+ * @param InputJax - MathJax TeX input jax / MathJax TeX 输入 jax
+ */
+export const clearUserState = (InputJax: TeX<LiteElement, string, HTMLElement>): void => {
+  for (const { handler, name } of USER_MAPS) {
+    const handlerMap = InputJax.parseOptions.handlers.get(handler);
+    const userMap = handlerMap.retrieve(name) as unknown as TeXMacroMap | null;
+
+    userMap?.map.clear();
+  }
+};


### PR DESCRIPTION
## Summary

Fixes user-defined TeX state leaking across documents when rendering multiple documents with a single `MathJax` instance (`plugin-mathjax` and `plugin-mathjax-slim`).

### Problem

- Macros/environments defined via `\newcommand`/`\def`/`\newenvironment` persist across documents because MathJax stores them in dedicated `new-*` maps that `InputJax.reset()` does **not** clear.
- `\label`/tag state also lingers, so rendering the same document twice with the same instance produces spurious "label multiply defined" errors.
- Users had to remember to call `reset()` manually between documents (SSR scenario).

### Fix

- Add `src/utils.ts` with `clearUserState()`, which clears MathJax's three user-defined tables (`new-Command`, `new-Environment`, `new-Delimiter`) on the instance, without touching built-in macro maps.
- Auto-reset after every `md.render`/`md.renderInline` via `try/finally` (same pattern as `plugin-katex`), clearing macros, environments, delimiters and labels.
- Keep the public `reset()` API for manual use.
- Update docs to note the automatic reset and recommend `tex.macros` for persistent macros.

### Tests

- New `state.spec.ts` in both packages (async + sync): reset is invoked after render/renderInline; `\newcommand` and `\newenvironment` do not leak across documents.
- Update "label multiply defined" tests: duplicate labels are now only detected when both occur within the same document.
- 100% istanbul coverage (statements/branches/functions/lines) in both packages; oxfmt + oxlint + markdownlint clean; tsc clean for the changed packages.