### PR TITLE
feat(plugin-anchor): add defaultPlaceHolder fallback for empty slugs

### DIFF
--- a/docs/src/anchor.md
+++ b/docs/src/anchor.md
@@ -92,6 +92,12 @@ const mdIt = MarkdownIt().use(anchor, { slugify: legacySlugify });
 - Default: `1`
 - Details: Starting index for duplicate slug numbering. Set to `2` to get `title`, `title-2`, `title-3`.
 
+### defaultPlaceHolder
+
+- Type: `string`
+- Default: `"heading"`
+- Details: Placeholder slug used when a heading has no text content and generates an empty slug (e.g. image-only headings).
+
 ### permalink
 
 - Type: `PermalinkGenerator`

--- a/docs/src/zh/anchor.md
+++ b/docs/src/zh/anchor.md
@@ -92,6 +92,12 @@ const mdIt = MarkdownIt().use(anchor, { slugify: legacySlugify });
 - 默认值：`1`
 - 详情：重复 slug 编号的起始索引。设为 `2` 可得到 `title`、`title-2`、`title-3`。
 
+### defaultPlaceHolder
+
+- 类型：`string`
+- 默认值：`"heading"`
+- 详情：当标题没有文本内容、生成的 slug 为空时（如纯图片标题）使用的占位 slug。
+
 ### permalink
 
 - 类型：`PermalinkGenerator`

--- a/packages/plugin-anchor/__tests__/basic.spec.ts
+++ b/packages/plugin-anchor/__tests__/basic.spec.ts
@@ -134,6 +134,76 @@ describe("slug options", () => {
       }).render("# Bar"),
     ).toBe('<h1 id="with-state-bar" tabindex="-1">Bar</h1>\n');
   });
+
+  it("should fall back to a stable slug for image-only headings", () => {
+    expect(md().render("# ![a](b)")).toBe(
+      '<h1 id="heading" tabindex="-1"><img src="b" alt="a"></h1>\n',
+    );
+  });
+
+  it("should fall back to a stable slug for empty headings", () => {
+    expect(md().render("# ")).toBe('<h1 id="heading" tabindex="-1"></h1>\n');
+  });
+
+  it("should deduplicate fallback slugs for multiple image-only headings", () => {
+    expect(md().render("# ![a](b)\n\n# ![c](d)")).toBe(
+      '<h1 id="heading" tabindex="-1"><img src="b" alt="a"></h1>\n<h1 id="heading-1" tabindex="-1"><img src="d" alt="c"></h1>\n',
+    );
+  });
+
+  it("should deduplicate fallback slug against existing slugs", () => {
+    expect(md().render("# Heading\n\n# ![a](b)")).toBe(
+      '<h1 id="heading" tabindex="-1">Heading</h1>\n<h1 id="heading-1" tabindex="-1"><img src="b" alt="a"></h1>\n',
+    );
+  });
+
+  it("should fall back to a stable slug when custom slugify returns empty", () => {
+    expect(md({ slugify: () => "" }).render("# ![a](b)")).toBe(
+      '<h1 id="heading" tabindex="-1"><img src="b" alt="a"></h1>\n',
+    );
+  });
+
+  it("should fall back to a stable slug when slugifyWithState returns empty", () => {
+    expect(md({ slugifyWithState: () => "" }).render("# ![a](b)")).toBe(
+      '<h1 id="heading" tabindex="-1"><img src="b" alt="a"></h1>\n',
+    );
+  });
+
+  it("should deduplicate fallback slugs for three image-only headings", () => {
+    expect(md().render("# ![a](b)\n\n# ![c](d)\n\n# ![e](f)")).toBe(
+      '<h1 id="heading" tabindex="-1"><img src="b" alt="a"></h1>\n<h1 id="heading-1" tabindex="-1"><img src="d" alt="c"></h1>\n<h1 id="heading-2" tabindex="-1"><img src="f" alt="e"></h1>\n',
+    );
+  });
+
+  it("should respect uniqueSlugStartIndex for fallback slugs", () => {
+    expect(md({ uniqueSlugStartIndex: 2 }).render("# ![a](b)\n\n# ![c](d)")).toBe(
+      '<h1 id="heading" tabindex="-1"><img src="b" alt="a"></h1>\n<h1 id="heading-2" tabindex="-1"><img src="d" alt="c"></h1>\n',
+    );
+  });
+
+  it("should use custom defaultPlaceHolder", () => {
+    expect(md({ defaultPlaceHolder: "section" }).render("# ![a](b)")).toBe(
+      '<h1 id="section" tabindex="-1"><img src="b" alt="a"></h1>\n',
+    );
+  });
+
+  it("should deduplicate custom defaultPlaceHolder for multiple image-only headings", () => {
+    expect(md({ defaultPlaceHolder: "section" }).render("# ![a](b)\n\n# ![c](d)")).toBe(
+      '<h1 id="section" tabindex="-1"><img src="b" alt="a"></h1>\n<h1 id="section-1" tabindex="-1"><img src="d" alt="c"></h1>\n',
+    );
+  });
+
+  it("should deduplicate custom defaultPlaceHolder against existing slugs", () => {
+    expect(md({ defaultPlaceHolder: "section" }).render("# Section\n\n# ![a](b)")).toBe(
+      '<h1 id="section" tabindex="-1">Section</h1>\n<h1 id="section-1" tabindex="-1"><img src="b" alt="a"></h1>\n',
+    );
+  });
+
+  it("should fall back to default placeholder when defaultPlaceHolder is empty", () => {
+    expect(md({ defaultPlaceHolder: "" }).render("# ![a](b)")).toBe(
+      '<h1 id="heading" tabindex="-1"><img src="b" alt="a"></h1>\n',
+    );
+  });
 });
 
 describe("tabIndex option", () => {

--- a/packages/plugin-anchor/__tests__/permalink-linkAfterHeader.spec.ts
+++ b/packages/plugin-anchor/__tests__/permalink-linkAfterHeader.spec.ts
@@ -112,7 +112,7 @@ describe("permalink.linkAfterHeader", () => {
         }),
       }).render("# ![img](url)"),
     ).toBe(
-      '<h1 id="" tabindex="-1"><img src="url" alt="img"></h1>\n<a class="header-anchor" href="#" aria-describedby="">X</a>',
+      '<h1 id="heading" tabindex="-1"><img src="url" alt="img"></h1>\n<a class="header-anchor" href="#heading" aria-describedby="heading">X</a>',
     );
   });
 

--- a/packages/plugin-anchor/src/options.ts
+++ b/packages/plugin-anchor/src/options.ts
@@ -70,6 +70,15 @@ export interface AnchorOptions {
   uniqueSlugStartIndex?: number;
 
   /**
+   * Placeholder slug used when a heading has no text content and generates an empty slug
+   *
+   * 当标题没有文本内容、生成的 slug 为空时使用的占位 slug
+   *
+   * @default "heading"
+   */
+  defaultPlaceHolder?: string;
+
+  /**
    * Permalink generator function
    *
    * 永久链接生成器函数
@@ -100,5 +109,13 @@ export interface AnchorOptions {
  */
 export type ResolvedAnchorOptions = AnchorOptions &
   Required<
-    Pick<AnchorOptions, "getTokensText" | "level" | "slugify" | "tabIndex" | "uniqueSlugStartIndex">
+    Pick<
+      AnchorOptions,
+      | "defaultPlaceHolder"
+      | "getTokensText"
+      | "level"
+      | "slugify"
+      | "tabIndex"
+      | "uniqueSlugStartIndex"
+    >
   >;

--- a/packages/plugin-anchor/src/plugin.ts
+++ b/packages/plugin-anchor/src/plugin.ts
@@ -5,7 +5,10 @@ import { defaultGetTokensText, defaultSlugify } from "./defaults.js";
 import type { AnchorOptions, ResolvedAnchorOptions } from "./options.js";
 import { isLevelSelectedArray, isLevelSelectedNumber, uniqueSlug } from "./utils.js";
 
+const DEFAULT_PLACE_HOLDER = "heading";
+
 const DEFAULTS = {
+  defaultPlaceHolder: DEFAULT_PLACE_HOLDER,
   getTokensText: defaultGetTokensText,
   level: 1,
   slugify: defaultSlugify,
@@ -17,6 +20,7 @@ export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void
   const resolvedOptions = Object.assign({}, DEFAULTS, options) as ResolvedAnchorOptions;
 
   const {
+    defaultPlaceHolder,
     level,
     slugify,
     slugifyWithState,
@@ -47,15 +51,17 @@ export const anchor: PluginWithOptions<AnchorOptions> = (md, options = {}): void
 
       let slug = token.attrGet("id");
 
-      slug =
-        slug == null
-          ? uniqueSlug(
-              slugifyWithState ? slugifyWithState(title, state) : slugify(title),
-              slugs,
-              false,
-              uniqueSlugStartIndex,
-            )
-          : uniqueSlug(slug, slugs, true, uniqueSlugStartIndex);
+      if (slug == null) {
+        slug = slugifyWithState ? slugifyWithState(title, state) : slugify(title);
+
+        // Fall back to a stable placeholder when the slug is empty
+        // (e.g. image-only or empty headings) to avoid invalid empty ids
+        if (!slug) slug = defaultPlaceHolder || DEFAULT_PLACE_HOLDER;
+
+        slug = uniqueSlug(slug, slugs, false, uniqueSlugStartIndex);
+      } else {
+        slug = uniqueSlug(slug, slugs, true, uniqueSlugStartIndex);
+      }
 
       token.attrSet("id", slug);
 


### PR DESCRIPTION
## Summary

Fixes an issue in `plugin-anchor` where headings with no text content (image-only headings like `# ![a](b)`, or empty headings like `# `) produced an **empty `id=""`** on the rendered heading, and multiple such headings deduplicated into `id="-1"`, `id="-2"`, etc. The fallback string is now exposed as a configurable option `defaultPlaceHolder` (default `"heading"`).

## Problem

`defaultGetTokensText` only collects `text`/`code_inline` tokens, so an image-only heading yields an empty title, which slugifies to an empty string. `uniqueSlug` then leaves the first empty slug as `""` and turns subsequent ones into `-1`, `-2`, producing invalid/anchor-broken ids.

## Fix

When the generated slug is empty, fall back to the `defaultPlaceHolder` option (default `"heading"`) before running `uniqueSlug`:

- `# ![a](b)` → `<h1 id="heading">`
- Multiple image-only headings → `heading`, `heading-1`, `heading-2`, …
- Customizable via `defaultPlaceHolder: "section"` → `section`, `section-1`, …
- The fallback deduplicates correctly against real heading slugs (e.g. `# Heading` → `heading`, then an image-only heading → `heading-1`).
- Works for both the `slugify` and `slugifyWithState` paths; behavior for text headings is unchanged.
- An empty-string `defaultPlaceHolder` falls back to `"heading"` to avoid invalid empty ids.

## New option

### `defaultPlaceHolder`

- Type: `string`
- Default: `"heading"`
- Details: Placeholder slug used when a heading has no text content and generates an empty slug (e.g. image-only headings).

## Tests

Added to `__tests__/basic.spec.ts` (`slug options`):

- Fallback for image-only headings and empty headings.
- Dedup across multiple image-only headings (`heading-1`, `heading-2`).
- Dedup against existing slugs.
- Fallback when a custom `slugify`/`slugifyWithState` returns an empty string.
- `uniqueSlugStartIndex` interaction with the fallback.
- Custom `defaultPlaceHolder` (`section`), including dedup across multiple headings and against a real `Section` slug.
- Empty-string `defaultPlaceHolder` falls back to `heading`.

Also updated `__tests__/permalink-linkAfterHeader.spec.ts` — its "no text heading" test previously pinned the buggy empty-id behavior (`id=""`, `href="#"`, `aria-describedby=""`); it now asserts the fixed output (`id="heading"`, `href="#heading"`, `aria-describedby="heading"`).

## Docs

- Added `defaultPlaceHolder` to `docs/src/anchor.md` and `docs/src/zh/anchor.md` (EN/ZH consistent).

## Verification

- `pnpm exec vitest run --coverage` (in `packages/plugin-anchor`): **84/84 tests passing**, **100%** statements/branches/functions/lines.
- `pnpm run lint:check`: clean.
- `pnpm run type-check`: clean.
