### PR TITLE
test(plugin-attrs): lock hr spacing boundary

### DIFF
--- a/packages/plugin-attrs/__tests__/rules/hr.spec.ts
+++ b/packages/plugin-attrs/__tests__/rules/hr.spec.ts
@@ -104,4 +104,18 @@ describe("hr detection", () => {
   it("should not convert mixed marker paragraphs", () => {
     expect(markdownIt.render("-*-{#id}")).toBe('<p id="id">-*-</p>\n');
   });
+
+  it("should lock the spacing boundary between markers and attrs", () => {
+    // 0 or 1 space directly following the marker run is treated as an hr;
+    // 2+ spaces fall back to a paragraph, with the attrs applied to the <p>.
+    const testCases = [
+      ["---{#id}", '<hr id="id">\n'],
+      ["--- {#id}", '<hr id="id">\n'],
+      ["---  {#id}", '<p id="id">--- </p>\n'],
+    ];
+
+    testCases.forEach(([src, expected]) => {
+      expect(markdownIt.render(src)).toBe(expected);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add a regression test locking the spacing boundary between an `hr` marker and its attributes in `plugin-attrs`.

### Background

The `hr` rule deliberately requires attributes to directly follow the marker run (0 or 1 space tolerance — see the `attrs must directly follow the marker run` guard in `src/rules/hr.ts`). As a result:

- `---{#id}` (0 space) → `<hr id="id">`
- `--- {#id}` (1 space) → `<hr id="id">`
- `---  {#id}` (2 spaces) → falls back to a paragraph: `<p id="id">--- </p>`

Most of this behavior was already covered by existing tests (0-space in "should support horizontal rules", 1-space-with-class in "should support multiple classes", 2-space in "should keep paragraph text between the markers and the attrs"). The one genuinely missing case was **single space + id** (`--- {#id}`), and there was no single assertion documenting the full 0/1/2-space matrix.

### Change

- Add `should lock the spacing boundary between markers and attrs` to `__tests__/rules/hr.spec.ts`, explicitly asserting the 0/1/2-space matrix.

### Tests

- Full attrs suite: 591 tests pass; istanbul coverage 100% (statements/branches/functions/lines).
- oxfmt + oxlint clean.