### PR TITLE
fix(plugin-field): keep dl markers inside items

### DIFF
--- a/packages/plugin-field/__tests__/interop.spec.ts
+++ b/packages/plugin-field/__tests__/interop.spec.ts
@@ -1,4 +1,5 @@
 import { container } from "@mdit/plugin-container";
+import { dl } from "@mdit/plugin-dl";
 import MarkdownIt from "markdown-it";
 import { describe, expect, it } from "vitest";
 
@@ -208,5 +209,40 @@ Another parent description.
     expect(result).toContain("Parent description");
     expect(result).toContain("Another parent description");
     expect(result).toMatchSnapshot();
+  });
+});
+
+describe("field with dl plugin", () => {
+  it("should keep definition lists inside a field item intact", () => {
+    const mdWithDl = MarkdownIt().use(field).use(dl);
+    const mdReverse = MarkdownIt().use(dl).use(field);
+
+    const src = `\
+::: fields
+@prop@
+Description text
+: definition term
+: another definition
+:::
+`;
+
+    // The `:` marker lines are dl syntax, not field container markers, so they
+    // must not terminate the field item. The definition list renders with the
+    // correct term instead of a stray literal `:`.
+    const expected = `\
+<dl class="field-wrapper fields-fields" data-kind="fields">
+<dt class="field-name" data-level="1">prop</dt>
+<dd class="field-content" data-level="1">
+<dl>
+<dt>Description text</dt>
+<dd>definition term</dd>
+<dd>another definition</dd>
+</dl>
+</dd>
+</dl>
+`;
+
+    expect(mdWithDl.render(src)).toBe(expected);
+    expect(mdReverse.render(src)).toBe(expected);
   });
 });

--- a/packages/plugin-field/package.json
+++ b/packages/plugin-field/package.json
@@ -50,7 +50,8 @@
     "@types/markdown-it": "^14.1.2"
   },
   "devDependencies": {
-    "@mdit/plugin-container": "workspace:*"
+    "@mdit/plugin-container": "workspace:*",
+    "@mdit/plugin-dl": "workspace:*"
   },
   "peerDependencies": {
     "markdown-it": "^14.2.0"

--- a/packages/plugin-field/src/rules.ts
+++ b/packages/plugin-field/src/rules.ts
@@ -326,12 +326,21 @@ export const getFieldItemRule =
       const nextMax = state.eMarks[nextLine];
       const nextIndent = state.sCount[nextLine] - state.blkIndent;
 
-      // A container marker at the container level ends the item
-      if (nextIndent <= MAX_COSMETIC_INDENT && state.src.charCodeAt(nextStart) === 58 /* : */)
-        break;
-
-      // Check if it's a field marker within the cosmetic indent range
       if (nextIndent <= MAX_COSMETIC_INDENT) {
+        // A field container marker (3+ colons) at the container level ends the
+        // item. A single `:` (e.g. definition list syntax) is not a container
+        // marker and must stay inside the item.
+        let colonCount = 0;
+
+        while (
+          nextStart + colonCount < nextMax &&
+          state.src.charCodeAt(nextStart + colonCount) === 58 /* : */
+        )
+          colonCount++;
+
+        if (colonCount >= MIN_MARKER_NUM) break;
+
+        // Check if it's a field marker within the cosmetic indent range
         const nextMarker = checkFieldMarker(state, nextStart, nextMax);
 
         // oxlint-disable-next-line typescript/strict-boolean-expressions

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -532,6 +532,9 @@ importers:
       '@mdit/plugin-container':
         specifier: workspace:*
         version: link:../plugin-container
+      '@mdit/plugin-dl':
+        specifier: workspace:*
+        version: link:../plugin-dl
 
   packages/plugin-figure:
     dependencies:


### PR DESCRIPTION
## Summary

Fix `plugin-field` breaking the `@mdit/plugin-dl` definition list interop: a definition-list line (`: term`) was wrongly terminating the current field item, producing a stray literal `:` inside the rendered `<dt>`.

### Problem

The field item boundary scan treated **any** line starting with `:` as a field container marker, even though a field container requires **3+** colons. When a definition list is placed inside a field item:

```
::: fields
@prop@
Description text
: definition term
: another definition
:::
```

the item ended prematurely at `: definition term`, so `Description text` never became the `<dt>` term and the `:` was rendered literally: `<dt>: definition term</dt>`.

### Fix

In `src/rules.ts`, the item boundary scan now counts leading colons and only terminates the item on a real field container marker (`>= MIN_MARKER_NUM` colons). Bare `:` / `::` lines (e.g. definition-list syntax) stay inside the item. This is a strict subset of the previous break set, so no new early-termination cases are introduced.

### Tests

- Add `field with dl plugin` regression test covering both `.use(field).use(dl)` and `.use(dl).use(field)` orders, asserting the definition list renders with the correct term.
- Add `@mdit/plugin-dl` to `devDependencies` (consistent with the existing `@mdit/plugin-container` test dependency).
- Full field suite: 109 tests pass; istanbul coverage 100% (statements/branches/functions/lines).
- oxfmt + oxlint clean; `plugin-field` source type-checks cleanly.