### PR TITLE
fix(plugin-tab): move render-time token mutation into core rule

### DIFF
--- a/docs/src/tab.md
+++ b/docs/src/tab.md
@@ -110,6 +110,11 @@ interface MarkdownItTabData {
 
 interface MarkdownItTabInfo {
   /**
+   * Identifier of tab container
+   */
+  id: string | undefined;
+
+  /**
    * Which tab is active
    *
    * @description -1 means no tab is active

--- a/docs/src/zh/tab.md
+++ b/docs/src/zh/tab.md
@@ -110,6 +110,11 @@ interface MarkdownItTabData {
 
 interface MarkdownItTabInfo {
   /**
+   * 选项卡容器标识符
+   */
+  id: string | undefined;
+
+  /**
    * 当前激活的选项卡
    *
    * @description -1 表示没有选项卡处于激活状态

--- a/packages/plugin-tab/__tests__/tab.spec.ts
+++ b/packages/plugin-tab/__tests__/tab.spec.ts
@@ -136,6 +136,14 @@ A **bold** text.
       });
     });
 
+    it("should not escape single quote in container and content id", () => {
+      const result = markdownIt.render("::: tabs#it's\n@tab A#tab's\ncontent\n:::\n");
+
+      expect(result).toContain('data-id="it\'s"');
+      expect(result).toContain('data-id="tab\'s"');
+      expect(result).not.toContain("it&#39;s");
+    });
+
     it("id with space", () => {
       const source = [
         `
@@ -1060,6 +1068,58 @@ content
       expect(result).toContain("A &amp; B");
       expect(result).not.toContain("&amp;amp;");
       expect(result).toContain('data-id="some-id"');
+    });
+  });
+
+  describe("render consistency", () => {
+    it("should produce identical output when the same token array is rendered multiple times", () => {
+      const source = `
+::: tabs
+@tab test1
+content 1
+@tab:active test2
+content 2
+:::
+`;
+      const tokens = markdownIt.parse(source, {});
+      const first = markdownIt.renderer.render(tokens, markdownIt.options, {});
+      const second = markdownIt.renderer.render(tokens, markdownIt.options, {});
+
+      expect(second).toBe(first);
+    });
+
+    it("should produce identical output for nested tabs rendered multiple times", () => {
+      const source = `
+::: tabs
+@tab A
+content A
+::: tabs
+@tab C
+content C
+:::
+@tab B
+content B
+:::
+`;
+      const tokens = markdownIt.parse(source, {});
+      const first = markdownIt.renderer.render(tokens, markdownIt.options, {});
+      const second = markdownIt.renderer.render(tokens, markdownIt.options, {});
+
+      expect(second).toBe(first);
+    });
+
+    it("should not throw when rendering tokens that bypassed the core rule", () => {
+      const mdInstance = new MarkdownIt().use(tab);
+      const tokens = mdInstance.parse("::: tabs\n@tab A\ncontent\n:::\n", {});
+
+      // simulate tokens that were not processed by the core rule (missing tabsData)
+      tokens
+        .filter((token) => token.type === "tabs_tabs_open")
+        .forEach((token) => {
+          delete (token.meta as Record<string, unknown>).tabsData;
+        });
+
+      expect(() => mdInstance.renderer.render(tokens, mdInstance.options, {})).not.toThrow();
     });
   });
 });

--- a/packages/plugin-tab/__tests__/tab.spec.ts
+++ b/packages/plugin-tab/__tests__/tab.spec.ts
@@ -201,6 +201,40 @@ content
       expect(result).toContain('class="tabs-tabs-wrapper"');
       expect(result).not.toContain("data-id");
     });
+
+    it("should pass container id to custom openRender via info.id", () => {
+      const mdInstance = new MarkdownIt().use(tab, {
+        name: "tabs",
+        openRender: (info) => `<div data-info-id="${info.id}">`,
+        closeRender: () => "</div>",
+      });
+
+      const result = mdInstance.render(`
+::: tabs#event
+@tab test
+content
+:::
+`);
+
+      expect(result).toContain('<div data-info-id="event">');
+    });
+
+    it("should pass undefined container id to custom openRender when no id is set", () => {
+      const mdInstance = new MarkdownIt().use(tab, {
+        name: "tabs",
+        openRender: (info) => `<div data-info-id="${info.id}">`,
+        closeRender: () => "</div>",
+      });
+
+      const result = mdInstance.render(`
+::: tabs
+@tab test
+content
+:::
+`);
+
+      expect(result).toContain('<div data-info-id="undefined">');
+    });
   });
 
   describe("should support tab id", () => {

--- a/packages/plugin-tab/src/options.ts
+++ b/packages/plugin-tab/src/options.ts
@@ -35,6 +35,13 @@ export interface MarkdownItTabData {
 
 export interface MarkdownItTabInfo {
   /**
+   * Identifier of tab container
+   *
+   * Tab 容器标识符
+   */
+  id: string | undefined;
+
+  /**
    * Which tab is active
    *
    * -1 means no tab is active 激活的 Tab

--- a/packages/plugin-tab/src/plugin.ts
+++ b/packages/plugin-tab/src/plugin.ts
@@ -1,6 +1,7 @@
 import { escapeHtml } from "@mdit/helper";
 import type { Options, PluginWithOptions } from "markdown-it";
 import type { RuleBlock } from "markdown-it/lib/parser_block.mjs";
+import type { RuleCore } from "markdown-it/lib/parser_core.mjs";
 import type Renderer from "markdown-it/lib/renderer.mjs";
 import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
 import type Token from "markdown-it/lib/token.mjs";
@@ -17,6 +18,11 @@ interface TabMeta {
   index: number;
   active: boolean;
   id?: string;
+}
+
+interface TabContainerMeta {
+  id?: string;
+  tabsData?: MarkdownItTabInfo;
 }
 
 interface TabEnv extends Record<string, unknown> {
@@ -327,80 +333,81 @@ const createTabContainerRule =
     return true;
   };
 
-const createTabsDataGetter =
-  (name: string): ((tokens: Token[], index: number) => MarkdownItTabInfo) =>
-  (tokens: Token[], index: number) => {
-    const data: MarkdownItTabData[] = [];
-    let activeIndex = -1;
-    let isTabStart = false;
-    let nestingDepth = 0;
-    const { level } = tokens[index];
+const createTabsCoreRule =
+  (name: string): RuleCore =>
+  (state) => {
+    const tokens = state.tokens;
 
-    for (
-      // skip the current tabs_open token
-      let i = index + 1;
-      i < tokens.length;
-      i++
-    ) {
-      const token = tokens[i];
-      const meta = token.meta as TabMeta;
-      const type = token.type;
+    for (let index = 0; index < tokens.length; index++) {
+      const token = tokens[index];
 
-      // record the nesting depth of tabs
-      if (type === `${name}_tabs_open`) {
-        nestingDepth++;
-        continue;
-      }
+      if (token.type !== `${name}_tabs_open`) continue;
 
-      if (type === `${name}_tabs_close`) {
-        if (token.level === level) break;
+      const data: MarkdownItTabData[] = [];
+      let activeIndex = -1;
+      let isTabStart = false;
+      let nestingDepth = 0;
+      const { level } = token;
 
-        nestingDepth--;
-        continue;
-      }
+      for (let i = index + 1; i < tokens.length; i++) {
+        const child = tokens[i];
+        const meta = child.meta as TabMeta;
+        const type = child.type;
 
-      // skip processing tokens deep inside other blocks
-      if (token.level > level + 1 || nestingDepth > 0) {
+        // record the nesting depth of tabs
+        if (type === `${name}_tabs_open`) {
+          nestingDepth++;
+          continue;
+        }
+
+        if (type === `${name}_tabs_close`) {
+          if (child.level === level) break;
+
+          nestingDepth--;
+          continue;
+        }
+
+        // skip processing tokens deep inside other blocks
+        if (child.level > level + 1 || nestingDepth > 0) {
+          // hide contents before first tab
+          if (!isTabStart) {
+            child.type = `${name}_tabs_empty`;
+            child.hidden = true;
+          }
+
+          continue;
+        }
+
+        if (type === `${name}_tab_open`) {
+          isTabStart = true;
+
+          meta.index = data.length;
+          // tab is active
+          if (meta.active) {
+            if (activeIndex === -1) activeIndex = data.length;
+            else meta.active = false;
+          }
+
+          data.push({
+            title: child.info,
+            index: data.length,
+            id: meta.id,
+            isActive: meta.active,
+          });
+
+          continue;
+        }
+
+        if (type === `${name}_tab_close`) continue;
+
         // hide contents before first tab
-        if (!isTabStart) {
-          token.type = `${name}_tabs_empty`;
-          token.hidden = true;
-        }
-
-        continue;
+        child.type = `${name}_tabs_empty`;
+        child.hidden = true;
       }
 
-      if (type === `${name}_tab_open`) {
-        isTabStart = true;
-
-        meta.index = data.length;
-        // tab is active
-        if (meta.active) {
-          if (activeIndex === -1) activeIndex = data.length;
-          else meta.active = false;
-        }
-
-        data.push({
-          title: token.info,
-          index: data.length,
-          id: meta.id,
-          isActive: meta.active,
-        });
-
-        continue;
-      }
-
-      if (type === `${name}_tab_close`) continue;
-
-      // hide contents before first tab
-      token.type = `${name}_tabs_empty`;
-      token.hidden = true;
+      // store the computed tab data for the renderer (rendering stays read-only)
+      (token.meta as TabContainerMeta).tabsData = { active: activeIndex, data };
     }
-
-    return {
-      active: activeIndex,
-      data,
-    };
   };
 
 const tabDataGetter = (tokens: Token[], index: number): MarkdownItTabData => {
@@ -426,14 +433,10 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
       index: number,
       _options: Options,
       _env: unknown,
-      self: Renderer,
+      _self: Renderer,
     ): string => {
       const { active, data } = info;
-      const token = tokens[index];
-
-      token.attrJoin("class", `${name}-tabs-wrapper`);
-      // oxlint-disable-next-line typescript/no-unsafe-member-access, typescript/strict-boolean-expressions
-      if (token.meta.id) token.attrJoin("data-id", token.meta.id as string);
+      const containerId = (tokens[index].meta as TabContainerMeta).id;
 
       const tabs = data.map(
         ({ title, id }, dataIndex) =>
@@ -445,7 +448,9 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
       );
 
       return `\
-<div${self.renderAttrs(token)}>
+<div class="${name}-tabs-wrapper"${
+        containerId ? ` data-id="${md.utils.escapeHtml(containerId)}"` : ""
+      }>
   <div class="${name}-tabs-header">
     ${tabs.join("\n    ")}
   </div>
@@ -461,22 +466,18 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
     // oxlint-disable-next-line max-params
     tabOpenRender = (
       info: MarkdownItTabData,
-      tokens: Token[],
-      index: number,
+      _tokens: Token[],
+      _index: number,
       _options: Options,
       _env: unknown,
-      self: Renderer,
+      _self: Renderer,
     ): string => {
-      const token = tokens[index];
-
-      token.attrJoin("class", `${name}-tab-content${info.isActive ? " active" : ""}`);
-      token.attrSet("data-index", info.index.toString());
-      if (info.id) token.attrSet("data-id", info.id);
-
-      if (info.isActive) token.attrJoin("data-active", "");
+      const { index, id, isActive } = info;
 
       return `\
-<div${self.renderAttrs(tokens[index])}>
+<div class="${name}-tab-content${isActive ? " active" : ""}" data-index="${index}"${
+        id ? ` data-id="${md.utils.escapeHtml(id)}"` : ""
+      }${isActive ? ' data-active=""' : ""}>
 `;
     },
 
@@ -485,7 +486,7 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
 `,
   } = options ?? {};
 
-  const tabsDataGetter = createTabsDataGetter(name);
+  const tabsCoreRule = createTabsCoreRule(name);
 
   md.block.ruler.before("fence", `${name}_tabs`, createTabContainerRule(name), {
     alt: ["paragraph", "reference", "blockquote", "list"],
@@ -495,8 +496,11 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
     alt: ["paragraph", "reference", "blockquote", "list"],
   });
 
+  md.core.ruler.push(`${name}_tabs_core`, tabsCoreRule);
+
   md.renderer.rules[`${name}_tabs_open`] = (tokens, index, mdItOptions, env, self): string => {
-    const info = tabsDataGetter(tokens, index);
+    // Fall back to an empty tab list if the tokens were not processed by the core rule
+    const info = (tokens[index].meta as TabContainerMeta).tabsData ?? { active: -1, data: [] };
 
     return openRender(info, tokens, index, mdItOptions, env, self);
   };

--- a/packages/plugin-tab/src/plugin.ts
+++ b/packages/plugin-tab/src/plugin.ts
@@ -1,8 +1,7 @@
 import { escapeHtml } from "@mdit/helper";
-import type { Options, PluginWithOptions } from "markdown-it";
+import type { PluginWithOptions } from "markdown-it";
 import type { RuleBlock } from "markdown-it/lib/parser_block.mjs";
 import type { RuleCore } from "markdown-it/lib/parser_core.mjs";
-import type Renderer from "markdown-it/lib/renderer.mjs";
 import type StateBlock from "markdown-it/lib/rules_block/state_block.mjs";
 import type Token from "markdown-it/lib/token.mjs";
 
@@ -309,7 +308,7 @@ const createTabContainerRule =
     openToken.markup = markup;
     openToken.block = true;
     openToken.info = name;
-    openToken.meta = { id };
+    openToken.meta = id ? { id } : {};
     openToken.map = [startLine, nextLine - (autoClosed ? 1 : 0)];
 
     state.env.tabName = name;
@@ -405,8 +404,14 @@ const createTabsCoreRule =
         child.hidden = true;
       }
 
+      const containerMeta = token.meta as TabContainerMeta;
+
       // store the computed tab data for the renderer (rendering stays read-only)
-      (token.meta as TabContainerMeta).tabsData = { active: activeIndex, data };
+      containerMeta.tabsData = {
+        active: activeIndex,
+        data,
+        id: containerMeta.id,
+      };
     }
   };
 
@@ -426,17 +431,8 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
   const {
     name = "tabs",
 
-    // oxlint-disable-next-line max-params
-    openRender = (
-      info: MarkdownItTabInfo,
-      tokens: Token[],
-      index: number,
-      _options: Options,
-      _env: unknown,
-      _self: Renderer,
-    ): string => {
-      const { active, data } = info;
-      const containerId = (tokens[index].meta as TabContainerMeta).id;
+    openRender = (info: MarkdownItTabInfo): string => {
+      const { active, data, id: containerId } = info;
 
       const tabs = data.map(
         ({ title, id }, dataIndex) =>
@@ -463,15 +459,7 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
 </div>
 `,
 
-    // oxlint-disable-next-line max-params
-    tabOpenRender = (
-      info: MarkdownItTabData,
-      _tokens: Token[],
-      _index: number,
-      _options: Options,
-      _env: unknown,
-      _self: Renderer,
-    ): string => {
+    tabOpenRender = (info: MarkdownItTabData): string => {
       const { index, id, isActive } = info;
 
       return `\
@@ -500,7 +488,8 @@ export const tab: PluginWithOptions<MarkdownItTabOptions> = (md, options) => {
 
   md.renderer.rules[`${name}_tabs_open`] = (tokens, index, mdItOptions, env, self): string => {
     // Fall back to an empty tab list if the tokens were not processed by the core rule
-    const info = (tokens[index].meta as TabContainerMeta).tabsData ?? { active: -1, data: [] };
+    const meta = tokens[index].meta as TabContainerMeta;
+    const info: MarkdownItTabInfo = meta.tabsData ?? { active: -1, data: [], id: meta.id };
 
     return openRender(info, tokens, index, mdItOptions, env, self);
   };


### PR DESCRIPTION
## Summary

Fixes a data-corruption bug in `plugin-tab`: the renderers mutated live tokens during rendering, so rendering the **same parsed token array** multiple times (e.g. "parse once + render many" for SSR caching or live preview) produced corrupted HTML — duplicated classes and a broken `data-active=" "`.

The fix also keeps **token `attrs` clean**, so users who write custom renderers (e.g. rendering a Vue component instead of HTML) receive a clean token plus structured data — not a token polluted with plugin-specific attributes.

## Problem

The renderers mutated live tokens during rendering:
- Default `openRender`/`tabOpenRender` did `attrJoin("class", ...)` / `attrSet("data-index", ...)` / `attrSet("data-id", ...)` / `attrJoin("data-active", "")`.
- A render-time getter mutated `token.type`, `token.hidden`, `meta.index`, `meta.active`.

`attrJoin` is not idempotent — a second render of the same tokens appended values again (`class="tabs-tabs-wrapper tabs-tabs-wrapper"`, `data-active=" "`).

## Fix

The parse-time **core rule** (`createTabsCoreRule`) now only does "parse structure" work:
- collects `{ active, data }` into `token.meta.tabsData`,
- sets `meta.index` / `meta.active`,
- hides content before the first tab (`type`/`hidden`).

It does **NOT** write any attributes onto tokens.

The default renderers are now **fully read-only**: they build their HTML string directly from the structured data (`info` / `meta`), never touching token attrs and never using `self.renderAttrs`.

Benefits:
- Rendering is side-effect free — `md.parse(src)` + multiple `renderer.render(tokens)` is safe (idempotent).
- Token `attrs` stay **clean** (`null`) — a custom `openRender`/`tabOpenRender` receives a clean token, structured `info`/`data`, and `meta.tabsData`, so it can output anything (HTML, Vue components, etc.) without unpicking plugin-injected attributes.
- **Single-render output is byte-for-byte identical to before** (all existing snapshots unchanged), including `data-id` escaping behavior (container/content keep the original markdown-it `escapeHtml` — apostrophes not escaped; the tab-button keeps `@mdit/helper`'s escaping, as before).
- A guard falls back to an empty tab list if tokens bypassed the core rule (no crash).

## Tests

Added a `render consistency` describe block in `__tests__/tab.spec.ts`:
- Same token array rendered twice → identical output.
- Nested tabs rendered twice → identical output.
- Rendering tokens that bypassed the core rule (missing `tabsData` meta) does not throw.
- Single-quote ids in container/content `data-id` are preserved (not `&#39;`).

All 63 tests pass with **100%** statements/branches/functions/lines coverage.

## Verification

- `pnpm exec vitest run --coverage` (in `packages/plugin-tab`): **63/63 tests passing**, **100%** coverage.
- `pnpm run lint:check`: clean.
- `pnpm run type-check`: clean.
