### PR TITLE
fix(plugin-layout): skip fence content in scans

### DIFF
--- a/packages/plugin-layout/__tests__/behavior.spec.ts
+++ b/packages/plugin-layout/__tests__/behavior.spec.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 
 import { layout } from "../src/index.js";
 
+const markdownIt = MarkdownIt().use(layout);
+
 describe(layout, () => {
   describe("inlineStyles option", () => {
     const mdNoInline = new MarkdownIt().use(layout, { inlineStyles: false });
@@ -87,6 +89,227 @@ Content
 <div style="display:flex">
 <div id="sidebar">
 <p>Content</p>
+</div>
+</div>
+`);
+    });
+  });
+
+  describe("code blocks", () => {
+    it("should not treat @end inside fenced code as a real end", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+\`\`\`md
+@end
+\`\`\`
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code class="language-md">@end
+</code></pre>
+<p>Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should not treat layout directives inside fenced code as real directives", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+\`\`\`md
+@flexs
+\`\`\`
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code class="language-md">@flexs
+</code></pre>
+<p>Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should not treat @end inside tilde fenced code as a real end", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+~~~
+@end
+~~~
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code>@end
+</code></pre>
+<p>Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should keep container content after a fenced code block", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+\`\`\`
+@end
+\`\`\`
+@flex
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<pre><code>@end
+</code></pre>
+<div>
+<p>Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should treat a short marker line as text, not a fence", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+~ab
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<p>~ab
+Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should not treat a backtick fence with a backtick in info as a fence", () => {
+      expect(markdownIt.render("@flexs\n@flex\n```a`b\nContent\n@end\n")).toBe(
+        '<div style="display:flex">\n<div>\n<p>```a`b\nContent</p>\n</div>\n</div>\n',
+      );
+    });
+
+    it("should auto-close container when the fence is unclosed", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+~~~js
+content
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code class="language-js">content
+</code></pre>
+</div>
+</div>
+`);
+    });
+
+    it("should keep indented lines inside a fence as code content", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+~~~js
+    indented
+~~~
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code class="language-js">    indented
+</code></pre>
+<p>Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should not close a fence with a shorter marker line", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+~~~~js
+~~~
+~~~~
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code class="language-js">~~~
+</code></pre>
+<p>Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should not close a fence with trailing content", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+~~~~js
+~~~~ trailing
+~~~~
+Content
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code class="language-js">~~~~ trailing
+</code></pre>
+<p>Content</p>
+</div>
+</div>
+`);
+    });
+
+    it("should not close a fence with an indented marker line", () => {
+      expect(
+        markdownIt.render(`\
+@flexs
+@flex
+~~~js
+    ~~~
+Content
+~~~
+@end
+`),
+      ).toBe(`\
+<div style="display:flex">
+<div>
+<pre><code class="language-js">    ~~~
+Content
+</code></pre>
 </div>
 </div>
 `);

--- a/packages/plugin-layout/src/plugin.ts
+++ b/packages/plugin-layout/src/plugin.ts
@@ -1,4 +1,4 @@
-import { escapeHtml } from "@mdit/helper";
+import { escapeHtml, scanFence } from "@mdit/helper";
 import type { BlockRule, PluginWithOptions } from "@mdit/helper";
 
 import { AT, CONTAINER_DISPLAY, LAYOUT_COLUMN, layoutKey } from "./constant.js";
@@ -6,6 +6,17 @@ import { detectDirective, parseAttributes } from "./directive.js";
 import type { MarkdownItLayoutOptions } from "./options.js";
 import type { LayoutMeta, LayoutStateBlock } from "./types.js";
 import { buildStyleString, resolveUtility } from "./utilities.js";
+
+// `scanFence` is provided by @mdit/helper (forked and modified from
+// markdown-it/lib/rules_block/fence.mjs).
+//
+// Known limitations: this scan runs at the container/item level, before
+// markdown-it's block rules re-tokenize nested content with a deeper
+// blkIndent. So lines inside a fence nested in a list item (indented 4+
+// spaces relative to the container), or inside indented code blocks /
+// lazy paragraph continuations, are not recognized as code here and their
+// `@`-directives are still honored (the same limitation exists in
+// @mdit/plugin-include's code block scan).
 
 /**
  * Count matching container opens/ends to find the `@end` that closes the container opened at
@@ -17,6 +28,7 @@ import { buildStyleString, resolveUtility } from "./utilities.js";
  * @param startLine - First line after the container open / 容器开始后的第一行
  * @param endLine - Search boundary / 搜索边界
  * @param depth - `@` depth of the container / 容器的 `@` 深度
+ * @param blkIndent - Indent of the container / 容器的缩进
  * @returns Line number of matching `@end`, or endLine if not found / 匹配 `@end` 的行号，未找到则返回 endLine
  */
 const findMatchingEnd = (
@@ -24,12 +36,21 @@ const findMatchingEnd = (
   startLine: number,
   endLine: number,
   depth: number,
+  blkIndent: number,
 ): number => {
   let nesting = 1;
 
   for (let line = startLine; line < endLine; line++) {
     const lineStart = state.bMarks[line] + state.tShift[line];
     const lineMax = state.eMarks[line];
+
+    // directives inside fenced code blocks are literal text, skip them
+    const fenceEnd = scanFence(state, line, endLine, blkIndent);
+
+    if (fenceEnd != null && fenceEnd > line) {
+      line = fenceEnd - 1;
+      continue;
+    }
 
     if (lineStart >= lineMax) continue;
     if (state.src.charCodeAt(lineStart) !== AT) continue;
@@ -79,6 +100,14 @@ const getItemRule = (): BlockRule => (state: LayoutStateBlock, startLine, endLin
   for (; nextLine < endLine; nextLine++) {
     const nextLineStart = state.bMarks[nextLine] + state.tShift[nextLine];
     const nextLineMax = state.eMarks[nextLine];
+
+    // directives inside fenced code blocks are literal text, skip them
+    const fenceEnd = scanFence(state, nextLine, endLine, indent);
+
+    if (fenceEnd != null && fenceEnd > nextLine) {
+      nextLine = fenceEnd - 1;
+      continue;
+    }
 
     if (nextLineStart >= nextLineMax) continue;
     if (state.src.charCodeAt(nextLineStart) !== AT) continue;
@@ -150,7 +179,7 @@ const getContainerRule = (): BlockRule => (state: LayoutStateBlock, startLine, e
 
   const indent = state.sCount[startLine];
   const parsedAttrs = parseAttributes(state.src, directive.nameEnd, max);
-  const nextLine = findMatchingEnd(state, startLine + 1, endLine, depth);
+  const nextLine = findMatchingEnd(state, startLine + 1, endLine, depth, indent);
 
   const oldParent = state.parentType;
   const oldLineMax = state.lineMax;


### PR DESCRIPTION
## Description

`findMatchingEnd` and the item end search in `plugin-layout` did not recognize code fences, so `@`-directives (`@end`, `@flex`, `@flexs`, ...) at the start of lines inside fenced code blocks were treated as real directives. This caused:

- A `@end` inside a fenced code block to prematurely close the container, truncating the fence and leaking the remaining content out of the container.
- A `@flexs` inside a fenced code block to wrongly increment container nesting, so the container auto-closed at the end of the document and swallowed the rest of it.

This is most easily hit in documentation that shows layout syntax examples inside fenced code blocks.

## Changes

- `scanFence` is now provided by `@mdit/helper` (extracted in #665), with `blkIndent` parameterized to match the container/item's own indent.
- Skip detected fence regions in both directive scan loops (`findMatchingEnd` and the item end-search), so directives inside fences are treated as literal code.
- Tests cover directives inside backtick and tilde fences, plus fence edge cases (short markers, backticks in info strings, unclosed fences, indented/shorter/trailing closing candidates) to match markdown-it fence semantics.

## Known limitations

As documented in the code comment, the scan runs before markdown-it re-tokenizes nested content with a deeper `blkIndent`. A fence nested inside a list item (indented 4+ spaces relative to the container), or a directive inside an indented code block / lazy paragraph continuation, is still honored. This mirrors the same limitation in `@mdit/plugin-include`'s code block scan.

## Checklist

- [x] Tests pass (100% coverage)
- [x] oxlint / oxfmt / type-check pass
