### PR TITLE
feat(helper): add scanFence

### DIFF
--- a/packages/helper/__tests__/markdown.spec.ts
+++ b/packages/helper/__tests__/markdown.spec.ts
@@ -1,0 +1,100 @@
+import MarkdownIt from "markdown-it";
+import type { StateBlock } from "markdown-it";
+import { describe, expect, it } from "vitest";
+
+import { scanFence } from "../src/markdown.js";
+
+const createState = (content: string, blkIndent = 0): StateBlock => {
+  const md = new MarkdownIt();
+  const state = new md.block.State(content, md, {}, []);
+
+  state.blkIndent = blkIndent;
+
+  return state;
+};
+
+describe(scanFence, () => {
+  it("should scan a closed backtick fence", () => {
+    const state = createState("```\ncode\n```\ntext");
+
+    expect(scanFence(state, 0, 4, 0)).toBe(3);
+  });
+
+  it("should scan a closed tilde fence", () => {
+    const state = createState("~~~\ncode\n~~~\n");
+
+    expect(scanFence(state, 0, 3, 0)).toBe(3);
+  });
+
+  it("should autoclose an unclosed fence at endLine", () => {
+    const state = createState("```\ncode");
+
+    expect(scanFence(state, 0, 2, 0)).toBe(2);
+  });
+
+  it("should return null for an indented code block", () => {
+    const state = createState("    ```\n");
+
+    expect(scanFence(state, 0, 1, 0)).toBeNull();
+  });
+
+  it("should return null for a too-short marker", () => {
+    const state = createState("`` a\n");
+
+    expect(scanFence(state, 0, 1, 0)).toBeNull();
+  });
+
+  it("should return null for a too-short line", () => {
+    const state = createState("ab\n");
+
+    expect(scanFence(state, 0, 1, 0)).toBeNull();
+  });
+
+  it("should return null when the line is not a fence", () => {
+    const state = createState("aaa\n");
+
+    expect(scanFence(state, 0, 1, 0)).toBeNull();
+  });
+
+  it("should return null when a backtick fence info contains a backtick", () => {
+    const state = createState("``` a`b\ncode\n```\n");
+
+    expect(scanFence(state, 0, 3, 0)).toBeNull();
+  });
+
+  it("should respect blkIndent for an indented fence", () => {
+    const state = createState("  ```\n  code\n  ```\n");
+
+    expect(scanFence(state, 0, 3, 2)).toBe(3);
+  });
+
+  it("should break when the closing line is outdented below blkIndent", () => {
+    const state = createState("  ```\n  code\n```\n");
+
+    expect(scanFence(state, 0, 3, 2)).toBe(2);
+  });
+
+  it("should not accept an over-indented closing line", () => {
+    const state = createState("```\ncode\n    ```\n");
+
+    expect(scanFence(state, 0, 3, 0)).toBe(3);
+  });
+
+  it("should not accept a shorter closing marker", () => {
+    const state = createState("```\ncode\n``\n");
+
+    expect(scanFence(state, 0, 3, 0)).toBe(3);
+  });
+
+  it("should not accept a closing line with trailing content", () => {
+    const state = createState("```\ncode\n``` x\n");
+
+    expect(scanFence(state, 0, 3, 0)).toBe(3);
+  });
+
+  it("should not accept a closing line with a different marker", () => {
+    const state = createState("```\ncode\n~~~\n");
+
+    expect(scanFence(state, 0, 3, 0)).toBe(3);
+  });
+});

--- a/packages/helper/src/index.ts
+++ b/packages/helper/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./dedent.js";
 export * from "./escape.js";
+export * from "./markdown.js";
 export * from "./reg.js";
 export type * from "./types.js";

--- a/packages/helper/src/markdown.ts
+++ b/packages/helper/src/markdown.ts
@@ -1,0 +1,76 @@
+/**
+ * Forked and modified from
+ * https://github.com/markdown-it/markdown-it/blob/master/lib/rules_block/fence.mjs
+ */
+
+import type { StateBlock } from "markdown-it";
+
+/**
+ * Scan the end line of a code fence block.
+ *
+ * 扫描代码围栏块的结束行。
+ *
+ * @param state - Block parser state / 块级解析器状态
+ * @param startLine - Start line of the fence / 围栏开始行
+ * @param endLine - Search boundary / 搜索边界
+ * @param blkIndent - Block indent of the current scope / 当前作用域的块级缩进
+ * @returns The line after the fence end, or `null` if the start line is not a fence /
+ *   围栏结束后的下一行；若起始行不是围栏则返回 `null`
+ */
+export const scanFence = (
+  state: StateBlock,
+  startLine: number,
+  endLine: number,
+  blkIndent: number,
+): number | null => {
+  let pos = state.bMarks[startLine] + state.tShift[startLine];
+  let max = state.eMarks[startLine];
+
+  // if it's indented more than 3 spaces, it should be a code block
+  if (state.sCount[startLine] - blkIndent >= 4) return null;
+
+  if (pos + 3 > max) return null;
+
+  const marker = state.src.charCodeAt(pos);
+
+  if (marker !== 0x7e /* ~ */ && marker !== 0x60 /* ` */) return null;
+
+  // scan marker length
+  let mem = pos;
+  pos = state.skipChars(pos, marker);
+  const len = pos - mem;
+
+  if (len < 3) return null;
+
+  const params = state.src.slice(pos, max);
+
+  if (marker === 0x60 /* ` */ && params.includes("`")) return null;
+
+  // search end of block
+  let nextLine = startLine;
+  let haveEndMarker = false;
+
+  for (;;) {
+    nextLine++;
+    if (nextLine >= endLine) break; // unclosed => autoclose at end
+
+    pos = mem = state.bMarks[nextLine] + state.tShift[nextLine];
+    max = state.eMarks[nextLine];
+
+    if (pos < max && state.sCount[nextLine] < blkIndent) break;
+
+    if (state.src.charCodeAt(pos) !== marker) continue;
+    if (state.sCount[nextLine] - blkIndent >= 4) continue;
+
+    pos = state.skipChars(pos, marker);
+    if (pos - mem < len) continue;
+
+    pos = state.skipSpaces(pos);
+    if (pos < max) continue;
+
+    haveEndMarker = true;
+    break;
+  }
+
+  return nextLine + (haveEndMarker ? 1 : 0);
+};


### PR DESCRIPTION
## Description

Both `fix/plugin-include-code-block` and `fix/plugin-layout-fence-directives` introduce a nearly identical `scanFence` function (forked from markdown-it's `rules_block/fence.mjs`) to detect code fence ranges while scanning markdown line by line.

This PR extracts the shared logic into `@mdit/helper` as a single `scanFence` export, parameterizing `blkIndent` so both use cases are covered:

- `plugin-include`: scans top-level content, passing `state.blkIndent` (always `0` at top level)
- `plugin-layout`: scans inside containers/items, passing the container's own indent

After this PR is merged, both branches will be updated to use the exported `scanFence` instead of their local copies.

## Changes

- `packages/helper/src/markdown.ts`: new `scanFence(state, startLine, endLine, blkIndent)` export
- `packages/helper/src/index.ts`: re-export `markdown.js`
- `packages/helper/__tests__/markdown.spec.ts`: unit tests with 100% coverage

## Checklist

- [x] Tests pass (29 tests, 100% coverage)
- [x] oxlint / oxfmt pass
