### PR TITLE
fix(plugin-include): skip code block directives

### DIFF
--- a/packages/plugin-include/__tests__/include.spec.ts
+++ b/packages/plugin-include/__tests__/include.spec.ts
@@ -8,7 +8,8 @@ import { describe, expect, it, vi } from "vitest";
 
 import { includePathsKey } from "../src/constant.js";
 import type { IncludeEnv } from "../src/index.js";
-import { include } from "../src/index.js";
+import { include, resolveInclude } from "../src/index.js";
+import type { MarkdownItIncludeOptions } from "../src/options.js";
 
 // Simulate an unreadable file (EACCES) for a specific marker path, delegating
 // all other fs calls to the real implementation so existing tests are unaffected.
@@ -969,5 +970,343 @@ describe("currentPath", () => {
 
     expect(rendered).toContain('src="./img.png"');
     expect(rendered).toContain('href="./link.md"');
+  });
+});
+
+describe("should not expand directives inside code blocks", () => {
+  it("should preserve directives inside fenced code block", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "```md\n<!-- @include: /path/to/foo.md -->\n```\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toBe(
+      '<pre><code class="language-md">&lt;!-- @include: /path/to/foo.md --&gt;\n</code></pre>\n',
+    );
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should preserve directives inside tilde fenced code block", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "~~~\n<!-- @include: /path/to/foo.md -->\n~~~\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toBe("<pre><code>&lt;!-- @include: /path/to/foo.md --&gt;\n</code></pre>\n");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should preserve directives inside indented code block", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "    <!-- @include: /path/to/foo.md -->\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toBe("<pre><code>&lt;!-- @include: /path/to/foo.md --&gt;\n</code></pre>\n");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should preserve directives after an unclosed fence", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source =
+      "```\n<!-- @include: /path/to/foo.md -->\n\n<!-- @include: /path/to/bar.md -->\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(rendered).toContain("@include: /path/to/bar.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should preserve directives inside fenced code block with useComment false", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+      useComment: false,
+    });
+
+    const source = "```md\n@include: /path/to/foo.md\n```\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toBe(
+      '<pre><code class="language-md">@include: /path/to/foo.md\n</code></pre>\n',
+    );
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should preserve directives inside deeply indented list code block", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "- item\n\n        <!-- @include: /path/to/foo.md -->\n\n- next\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should preserve directives with blockquote prefix", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "> quote\n>\n>     <!-- @include: /path/to/foo.md -->\n>\n> more\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should not run code detection when no directive exists", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "```md\nsome code\n```\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toBe('<pre><code class="language-md">some code\n</code></pre>\n');
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should not expand directives inside code block of deep included file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "include-codeblock-"));
+    writeFileSync(join(dir, "a.md"), "```md\n<!-- @include: b.md -->\n```\n");
+
+    try {
+      const mdWithOptions = MarkdownIt({ html: true })
+        .use(include, {
+          currentPath: (env: IncludeEnv) => env.filePath as string,
+          deep: true,
+        })
+        .use(container, { name: "tip" });
+      const env: IncludeEnv = { filePath: join(dir, "index.md") };
+
+      const rendered = mdWithOptions.render("<!-- @include: a.md -->", env);
+
+      expect(rendered).toContain("@include: b.md");
+      expect(env.includedFiles).toStrictEqual([join(dir, "a.md")]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("should preserve directives inside a multi-line indented code block", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "    line one\n    <!-- @include: /path/to/foo.md -->\n    line three\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(rendered).not.toContain("File not found");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should expand directives between two code blocks only", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = [
+      "```",
+      "<!-- @include: /path/to/a.md -->",
+      "```",
+      "",
+      "<!-- @include: /path/to/b.md -->",
+      "",
+      "```",
+      "<!-- @include: /path/to/c.md -->",
+      "```",
+    ].join("\n");
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/a.md");
+    expect(rendered).toContain("@include: /path/to/c.md");
+    expect(rendered).toContain("File not found");
+    expect(env.includedFiles).toStrictEqual(["/path/to/b.md"]);
+  });
+
+  it("should treat a fence with backtick in info as non-fence", () => {
+    // ```a`b 不是合法围栏（语言标识含反引号）→ 指令照常展开
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "```a`b\n<!-- @include: /path/to/foo.md -->\n```\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("File not found");
+    expect(env.includedFiles).toStrictEqual(["/path/to/foo.md"]);
+  });
+
+  it("should keep looking for a closing fence after an over-indented fence line", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    // 4 空格缩进的 ``` 不闭合；随后的 ``` 才是闭合 → 指令保留在围栏内
+    const source = "```\n<!-- @include: /path/to/foo.md -->\n    ```\n```\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should keep looking for a longer closing fence", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    // 开围栏 4 反引号；3 反引号行不闭合；4 反引号行闭合 → 指令保留
+    const source = "````\n<!-- @include: /path/to/foo.md -->\n```\n````\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should keep looking for a closing fence with trailing content", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    // "``` extra" 尾随非空白不闭合；随后的 ``` 闭合 → 指令保留
+    const source = "```\n<!-- @include: /path/to/foo.md -->\n``` extra\n```\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should end an indented code block at a non-indented line", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    // 行 0 缩进代码块（指令保留）；行 1 非缩进结束代码块
+    const source = "    <!-- @include: /path/to/foo.md -->\nplain\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should treat an indented line after a blank line as code block", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    // 行 2 前有空行 → 缩进代码块（指令保留）
+    const source = "text\n\n    <!-- @include: /path/to/foo.md -->\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should expand a 4-space indented directive following a paragraph line", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    // 行 1 紧接段落（无空行）→ 是段落懒续行而非代码块 → 指令展开
+    const source = "text\n    <!-- @include: /path/to/foo.md -->\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("File not found");
+    expect(env.includedFiles).toStrictEqual(["/path/to/foo.md"]);
+  });
+
+  it("should handle trailing empty lines after a code block", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    const source = "```\n<!-- @include: /path/to/foo.md -->\n```\n\n\n";
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("@include: /path/to/foo.md");
+    expect(env.includedFiles).toStrictEqual([]);
+  });
+
+  it("should keep line numbers accurate after a multi-line directive", () => {
+    const md = MarkdownIt({ html: true }).use(include, {
+      currentPath: (env: IncludeEnv) => env.filePath as string,
+    });
+
+    // 多行指令（`<!--\n  @include: ... -->`）内部含换行，不应使后续行号欠计数
+    const source = [
+      "<!--",
+      "  @include: /path/to/foo.md",
+      "-->",
+      "",
+      "```",
+      "<!-- @include: /path/to/bar.md -->",
+      "```",
+    ].join("\n");
+    const env: IncludeEnv = { filePath: __filename };
+    const rendered = md.render(source, env);
+
+    expect(rendered).toContain("File not found");
+    expect(rendered).toContain("@include: /path/to/bar.md");
+    expect(env.includedFiles).toStrictEqual(["/path/to/foo.md"]);
+  });
+
+  it("should support calling resolveInclude directly", () => {
+    const dir = mkdtempSync(join(tmpdir(), "include-direct-"));
+    writeFileSync(join(dir, "a.md"), "# A\n");
+
+    try {
+      const md = MarkdownIt({ html: true });
+      const options = {
+        currentPath: (): string => join(dir, "index.md"),
+        resolvePath: (filePath: string): string => filePath,
+        deep: true,
+        resolveLinkPath: true,
+        resolveImagePath: true,
+        useComment: true,
+      } as Required<MarkdownItIncludeOptions>;
+      const includedFiles: string[] = [];
+      const result = resolveInclude(
+        "<!-- @include: a.md -->",
+        options,
+        { cwd: dir, includedFiles },
+        [],
+        md,
+      );
+
+      expect(result).toContain("# A");
+      expect(includedFiles).toStrictEqual([join(dir, "a.md")]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/plugin-include/src/plugin.ts
+++ b/packages/plugin-include/src/plugin.ts
@@ -1,9 +1,9 @@
 // oxlint-disable-next-line import/no-nodejs-modules
 import { existsSync, readFileSync, statSync } from "node:fs";
 
-import { NEWLINE_RE, dedent } from "@mdit/helper";
+import { NEWLINE_RE, dedent, scanFence } from "@mdit/helper";
 import type { BlockRule, CoreRule, PluginWithOptions } from "@mdit/helper";
-import type { Token } from "markdown-it";
+import type { MarkdownIt, StateBlock, Token } from "markdown-it";
 import { isAbsolute, resolve, relative, join, dirname } from "upath";
 
 import { includePathsKey } from "./constant.js";
@@ -161,61 +161,120 @@ export const handleInclude = (
   return dedent(results.join("\n").replace(/\n?$/, "\n"));
 };
 
+// Forked and modified from markdown-it/lib/rules_block/code.mjs
+const scanCode = (state: StateBlock, startLine: number, endLine: number): number => {
+  if (state.sCount[startLine] - state.blkIndent < 4) return startLine;
+
+  let nextLine = startLine + 1;
+  let last = nextLine;
+
+  while (nextLine < endLine) {
+    if (state.isEmpty(nextLine)) {
+      nextLine++;
+      continue;
+    }
+
+    if (state.sCount[nextLine] - state.blkIndent >= 4) {
+      nextLine++;
+      last = nextLine;
+      continue;
+    }
+    break;
+  }
+
+  return last;
+};
+
+// Locate fenced / indented code blocks, reusing markdown-it's block structure
+const scanCodeRanges = (content: string, md: MarkdownIt): [number, number][] => {
+  const state = new md.block.State(content, md, {}, []);
+  const ranges: [number, number][] = [];
+  let line = 0;
+
+  while (line < state.lineMax) {
+    line = state.skipEmptyLines(line);
+    if (line >= state.lineMax) break;
+
+    const fenceEnd = scanFence(state, line, state.lineMax, state.blkIndent);
+
+    if (fenceEnd != null && fenceEnd > line) {
+      ranges.push([line, fenceEnd]);
+      line = fenceEnd;
+      continue;
+    }
+
+    // indented code blocks can't directly follow a paragraph line (markdown-it
+    // treats such lines as lazy continuation), so require a blank line before
+    const codeEnd = scanCode(state, line, state.lineMax);
+
+    if (codeEnd > line && (line === 0 || state.isEmpty(line - 1))) {
+      ranges.push([line, codeEnd]);
+      line = codeEnd;
+      continue;
+    }
+
+    line++;
+  }
+
+  return ranges;
+};
+
 export const resolveInclude = (
   content: string,
   options: Required<MarkdownItIncludeOptions>,
   { cwd, includedFiles, stack = [] }: IncludeInfo,
-): string =>
-  content.replace(
-    options.useComment ? INCLUDE_COMMENT_RE : INCLUDE_RE,
-    // oxlint-disable-next-line max-params
-    (
-      _,
-      indent: string,
-      includePath: string,
-      region?: string,
-      lineStart?: string,
-      lineEnd?: string,
-    ) => {
-      const actualPath = options.resolvePath(includePath, cwd);
-      const realPath = isAbsolute(actualPath)
-        ? actualPath
-        : cwd
-          ? resolve(cwd, actualPath)
-          : actualPath;
-      const resolvedPath = options.resolveImagePath || options.resolveLinkPath;
+  codeRanges: [number, number][],
+  md: MarkdownIt,
+): string => {
+  const expand = (
+    indent: string,
+    includePath: string,
+    region?: string,
+    lineStart?: string,
+    lineEnd?: string,
+  ): string => {
+    const actualPath = options.resolvePath(includePath, cwd);
+    const realPath = isAbsolute(actualPath)
+      ? actualPath
+      : cwd
+        ? resolve(cwd, actualPath)
+        : actualPath;
+    const resolvedPath = options.resolveImagePath || options.resolveLinkPath;
 
-      // Detect circular includes in the current deep include chain: if this
-      // file is already being processed, skip it instead of recursing forever.
-      if (stack.includes(realPath)) {
-        // oxlint-disable-next-line no-console
-        console.error(`[@mdit/plugin-include]: Circular include detected: ${realPath}`);
+    // Detect circular includes in the current deep include chain: if this
+    // file is already being processed, skip it instead of recursing forever.
+    if (stack.includes(realPath)) {
+      // oxlint-disable-next-line no-console
+      console.error(`[@mdit/plugin-include]: Circular include detected: ${realPath}`);
 
-        return "";
-      }
+      return "";
+    }
 
-      const fileContent = handleInclude(
-        Object.assign(
-          { filePath: actualPath },
-          region
-            ? { region }
-            : {
-                // oxlint-disable-next-line no-undefined
-                lineStart: lineStart ? Number(lineStart) : undefined,
-                // oxlint-disable-next-line no-undefined
-                lineEnd: lineEnd ? Number(lineEnd) : undefined,
-              },
-        ),
-        { cwd, includedFiles, resolvedPath },
-      );
+    const fileContent = handleInclude(
+      Object.assign(
+        { filePath: actualPath },
+        region
+          ? { region }
+          : {
+              // oxlint-disable-next-line no-undefined
+              lineStart: lineStart ? Number(lineStart) : undefined,
+              // oxlint-disable-next-line no-undefined
+              lineEnd: lineEnd ? Number(lineEnd) : undefined,
+            },
+      ),
+      { cwd, includedFiles, resolvedPath },
+    );
 
-      let included = fileContent;
+    let included = fileContent;
 
-      if (options.deep && actualPath.endsWith(".md")) {
-        stack.push(realPath);
+    if (options.deep && actualPath.endsWith(".md")) {
+      stack.push(realPath);
 
-        try {
-          included = resolveInclude(fileContent, options, {
+      try {
+        included = resolveInclude(
+          fileContent,
+          options,
+          {
             cwd: isAbsolute(actualPath)
               ? dirname(actualPath)
               : cwd
@@ -223,18 +282,71 @@ export const resolveInclude = (
                 : null,
             includedFiles,
             stack,
-          });
-        } finally {
-          stack.pop();
-        }
+          },
+          scanCodeRanges(fileContent, md),
+          md,
+        );
+      } finally {
+        stack.pop();
       }
+    }
 
-      return included
-        .split("\n")
-        .map((line) => indent + line)
-        .join("\n");
-    },
-  );
+    return included
+      .split("\n")
+      .map((line) => indent + line)
+      .join("\n");
+  };
+
+  // use a local regex instance so nested (deep) calls don't share lastIndex
+  const { source, flags } = options.useComment ? INCLUDE_COMMENT_RE : INCLUDE_RE;
+  const lineRegex = new RegExp(source, flags);
+  let result = "";
+  let lastCopied = 0;
+  let lineNumber = 0;
+  let rangeIndex = 0;
+  let match: RegExpExecArray | null;
+
+  // count newlines in [from, to) to track the current line number
+  const countNewlines = (from: number, to: number): number => {
+    let count = 0;
+
+    for (let i = from; i < to; i++) if (content.charCodeAt(i) === 10 /* \n */) count++;
+
+    return count;
+  };
+
+  while ((match = lineRegex.exec(content)) != null) {
+    const { index } = match;
+    const full = match[0];
+
+    lineNumber += countNewlines(lastCopied, index);
+
+    // advance to the code range covering the current line
+    while (rangeIndex < codeRanges.length && codeRanges[rangeIndex][1] <= lineNumber) rangeIndex++;
+
+    const inCode =
+      rangeIndex < codeRanges.length &&
+      lineNumber >= codeRanges[rangeIndex][0] &&
+      lineNumber < codeRanges[rangeIndex][1];
+
+    if (inCode) {
+      // inside a code block: keep everything up to the match end literal
+      result += content.slice(lastCopied, index + full.length);
+      lastCopied = index + full.length;
+      lineNumber += countNewlines(index, index + full.length);
+      continue;
+    }
+
+    const [, indent, includePath, region, lineStart, lineEnd] = match;
+
+    result +=
+      content.slice(lastCopied, index) + expand(indent, includePath, region, lineStart, lineEnd);
+    lastCopied = index + full.length;
+    lineNumber += countNewlines(index, index + full.length);
+  }
+
+  return result + content.slice(lastCopied);
+};
 
 const SYNTAX_PUSH_RE = /^<!-- #include-env-start: (?<includePath>[^)]*?) -->$/;
 
@@ -330,6 +442,13 @@ export const include: PluginWithOptions<MarkdownItIncludeOptions> = (md, options
     const includedFiles = (env.includedFiles ??= []);
     const filePath = currentPath(env);
 
+    // fast path: no directive keyword at all → nothing to expand
+    if (!state.src.includes("@include")) return;
+
+    // reuse markdown-it's block structure to locate fenced/indented code
+    // blocks, so directive-looking lines inside code examples stay literal
+    const codeRanges = scanCodeRanges(state.src, md);
+
     state.src = resolveInclude(
       state.src,
       {
@@ -344,6 +463,8 @@ export const include: PluginWithOptions<MarkdownItIncludeOptions> = (md, options
         cwd: filePath ? dirname(filePath) : null,
         includedFiles,
       },
+      codeRanges,
+      md,
     );
   };
 


### PR DESCRIPTION
## Description

`plugin-include` performs inclusion at the core stage by replacing include directives (`@include:` / `<!-- @include: -->`) in the source string. The line-based regex scan ran on every line, so include directives inside fenced or indented code blocks were wrongly expanded, breaking code samples that contain the include syntax.

This PR fixes it by reusing markdown-it's own block structure to locate code block ranges before expanding:

- Build a `StateBlock` from the file content via `new md.block.State(...)`
- Reuse markdown-it's `fence` / `code` detection to find fenced and indented code block ranges
- Skip any include directive whose line falls inside a code range during expansion

The `scanFence` helper is now imported from `@mdit/helper` (extracted in #665); `scanCode` remains local to the plugin.

### Known limitations (documented in code)

- Directives inside indented code blocks that directly follow a heading / hr / closing fence may still be expanded (markdown-it treats those lines as non-paragraph block boundaries). Full fix requires paragraph terminator detection and is left for a separate PR.

## Changes

- `packages/plugin-include/src/plugin.ts`: detect fenced / indented code block ranges and skip directives inside them
- `packages/plugin-include/__tests__/include.spec.ts`: tests for directives inside fenced / indented code blocks, multi-line directives, deep includes, etc.

## Checklist

- [x] Tests pass (100% coverage)
- [x] oxlint / oxfmt / type-check pass
